### PR TITLE
Fix markdown syntax error in documentation

### DIFF
--- a/docs/management/health.md
+++ b/docs/management/health.md
@@ -35,7 +35,7 @@ At present, Steeltoe provides the following `IHealthContributor` implementations
 |Name|Description|
 |---|---|
 |`DiskSpaceContributor`|checks for low disk space, configure using `DiskSpaceContributorOptions`|
-|`RabbitMQHealthContributor|checks RabbitMQ connection health|
+|`RabbitMQHealthContributor`|checks RabbitMQ connection health|
 |`RedisHealthContributor`|checks Redis cache connection health|
 |`RelationalHealthContributor`|checks relational database connection health (MySql, Postgres, SqlServer)|
 


### PR DESCRIPTION
The table under Health Contributors doesn't render.

https://steeltoe.io/docs/7-management/6-%252fhealth