### PR TITLE
API Browser Navigation Enhancements

### DIFF
--- a/api-filter.yml
+++ b/api-filter.yml
@@ -1,5 +1,8 @@
 apiRules:
 - exclude:
+    uidRegex: ^OpenCensus\.*
+    type: Namespace
+- exclude:
     uidRegex: ^Microsoft\.Diagnostics\.Runtime\.Interop$
     type: Namespace
 - exclude:

--- a/template/steeltoe/partials/toc.tmpl.partial
+++ b/template/steeltoe/partials/toc.tmpl.partial
@@ -21,7 +21,7 @@
         <div id="api-selection">
             <select id="api-namespace-v3" class="form-control api-namespace">
               <option value="/api/browser/v3/all/Steeltoe.CircuitBreaker.html">All Namespaces</option>
-              <option value="/api/browser/v3/circuitbreaker/Steeltoe.CircuitBreaker.Hystrix.html">Steeltoe.CircuitBreaker</option>
+              <option value="/api/browser/v3/circuitbreaker/Steeltoe.CircuitBreaker.html">Steeltoe.CircuitBreaker</option>
               <option value="/api/browser/v3/configuration/Steeltoe.Extensions.Configuration.html">Steeltoe.Extensions.Configuration</option>
               <option value="/api/browser/v3/connectors/Steeltoe.Connector.html">Steeltoe.Connector</option>
               <option value="/api/browser/v3/discovery/Steeltoe.Discovery.html">Steeltoe.Discovery</option>

--- a/template/steeltoe/styles/main.css
+++ b/template/steeltoe/styles/main.css
@@ -116,11 +116,11 @@ pre {
 	z-index: 1;
 }
 .sidefilter {
-	top: 184px;
+	top: 138px;
 	width: 260px;
 }
 .sidetoc {
-	top: 235px;
+	top: 203px;
 	width: 260px;
 }
 .btn.active, .btn:active {
@@ -207,13 +207,14 @@ pre {
     padding: 15px;
 }
 
-.api-browser .sidetoc {
-    z-index: 25;
-}
-
 .api-browser .sidefilter {
     top: 195px;
     z-index: 50;
+}
+
+.api-browser .sidetoc {
+	top: 235px;
+    z-index: 25;
 }
 
 select.api-namespace {


### PR DESCRIPTION
- Remove style bleed from api browser nav into docs nav
- Remove OpenCensus namespace from metadata results
- Consistent namespace linking for default namespace