### PR TITLE
Restore Header Spacing in Mobile View

### DIFF
--- a/template/steeltoe/styles/main.css
+++ b/template/steeltoe/styles/main.css
@@ -512,8 +512,4 @@ ul.blog-list > :first-child .blog-date::after {
 		width: 100%;
 		padding: 0px;
 	}
-
-	.sidenav {
-		padding: 0px 0px 0px 5%;
-	}
 }


### PR DESCRIPTION
`Table of Contents` button was running into logo in mobile view

Previous:
![OldHeader](https://user-images.githubusercontent.com/49496839/109712699-fc50d000-7b65-11eb-9714-839f9b1c101d.png)

New:
![NewHeader](https://user-images.githubusercontent.com/49496839/109712712-feb32a00-7b65-11eb-9d47-7e45b19193c4.png)