### PR TITLE
DocFX Metadata Compatibility with Linux/OSX

### DIFF
--- a/api-all.json
+++ b/api-all.json
@@ -15,7 +15,7 @@
     "disableDefaultFilter": false,
     "filter": "api-filter.yml",
     "properties": {
-      "TargetFramework": "net46"
+      "TargetFramework": "netcoreapp3.1"
     },
     "version": "2.all"
   },

--- a/api-filter.yml
+++ b/api-filter.yml
@@ -8,3 +8,7 @@ apiRules:
 - exclude:
     uidRegex: ^Microsoft\.Extensions\.DependencyInjection$
     type: Namespace
+# Excluding Steeltoe.Messaging.RabbitMQ.* namespaces clears issue #147
+- exclude:
+    uidRegex: ^Steeltoe\.Messaging\.RabbitMQ\.*
+    type: Namespace

--- a/api-v2.json
+++ b/api-v2.json
@@ -15,7 +15,7 @@
     "disableDefaultFilter": false,
     "filter": "api-filter.yml",
     "properties": {
-      "TargetFramework": "net46"
+      "TargetFramework": "netcoreapp3.1"
     },
     "version": "2.x"
   },
@@ -34,7 +34,7 @@
     "disableDefaultFilter": false,
     "filter": "api-filter.yml",
     "properties": {
-      "TargetFramework": "net46"
+      "TargetFramework": "netcoreapp3.1"
     },
     "version": "2.x"
   },
@@ -53,7 +53,7 @@
     "disableDefaultFilter": false,
     "filter": "api-filter.yml",
     "properties": {
-      "TargetFramework": "net46"
+      "TargetFramework": "netcoreapp3.1"
     },
     "version": "2.x"
   },
@@ -72,7 +72,7 @@
     "disableDefaultFilter": false,
     "filter": "api-filter.yml",
     "properties": {
-      "TargetFramework": "net46"
+      "TargetFramework": "netcoreapp3.1"
     },
     "version": "2.x"
   },
@@ -91,7 +91,7 @@
     "disableDefaultFilter": false,
     "filter": "api-filter.yml",
     "properties": {
-      "TargetFramework": "net46"
+      "TargetFramework": "netcoreapp3.1"
     },
     "version": "2.x"
   },
@@ -110,7 +110,7 @@
     "disableDefaultFilter": false,
     "filter": "api-filter.yml",
     "properties": {
-      "TargetFramework": "net46"
+      "TargetFramework": "netcoreapp3.1"
     },
     "version": "2.x"
   },
@@ -129,7 +129,7 @@
     "disableDefaultFilter": false,
     "filter": "api-filter.yml",
     "properties": {
-      "TargetFramework": "net46"
+      "TargetFramework": "netcoreapp3.1"
     },
     "version": "2.x"
   },
@@ -148,7 +148,7 @@
     "disableDefaultFilter": false,
     "filter": "api-filter.yml",
     "properties": {
-      "TargetFramework": "net46"
+      "TargetFramework": "netcoreapp3.1"
     },
     "version": "2.x"
   },
@@ -167,7 +167,7 @@
     "disableDefaultFilter": false,
     "filter": "api-filter.yml",
     "properties": {
-      "TargetFramework": "net46"
+      "TargetFramework": "netcoreapp3.1"
     },
     "version": "2.x"
   },
@@ -186,7 +186,7 @@
     "disableDefaultFilter": false,
     "filter": "api-filter.yml",
     "properties": {
-      "TargetFramework": "net46"
+      "TargetFramework": "netcoreapp3.1"
     },
     "version": "2.x"
   },
@@ -205,7 +205,7 @@
     "disableDefaultFilter": false,
     "filter": "api-filter.yml",
     "properties": {
-      "TargetFramework": "net46"
+      "TargetFramework": "netcoreapp3.1"
     },
     "version": "2.x"
   }


### PR DESCRIPTION
- Exclude packages causing metadata build issues on Linux/OSX environments
- Set target framework to .NET Core 3.1 for version 2 (2.x branch) metadata being generated

Closes #147 