### PR TITLE
Welcome page links, CF Actuator Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /sources/
 /.vscode/
 /.vs/
+_site

--- a/api/v3/management/cloud-foundry.md
+++ b/api/v3/management/cloud-foundry.md
@@ -41,7 +41,7 @@ The default path to the Cloud Foundry endpoint is computed by combining the glob
 
 See the [HTTP Access](./using-endpoints.md#http-access) section to see the overall steps required to enable HTTP access to endpoints in an ASP.NET Core application.
 
-The Cloud Foundry actuator, the Cloud Foundry actuator's security middleware and CORS policy can be added to the application in either `program.cs` or `startup.cs` and either specifically or in a grouping with all the other actuators. All of these options can function effectively the same way, so this may be interpreted as a style choice.
+The Cloud Foundry actuator, the actuator's security middleware, and the CORS policy can be added to the application in either `program.cs` or `startup.cs`. This can be done individually or in a grouping with all the other actuators. All of these options will function effectively the same way, so this is a style choice.
 
 >Of all the options provided, the approach of using `AddAllActuators()` on the `HostBuilder` is most recommended.
 

--- a/api/v3/management/cloud-foundry.md
+++ b/api/v3/management/cloud-foundry.md
@@ -41,7 +41,7 @@ The default path to the Cloud Foundry endpoint is computed by combining the glob
 
 See the [HTTP Access](./using-endpoints.md#http-access) section to see the overall steps required to enable HTTP access to endpoints in an ASP.NET Core application.
 
-The Cloud Foundry actuator, it's security middleware and CORS policy can be added to the application in either `program.cs` or `startup.cs` and either specifically or in a grouping with all the other actuators. All of these options can function effectively the same way, so this may be interpreted as a style choice.
+The Cloud Foundry actuator, the Cloud Foundry actuator's security middleware and CORS policy can be added to the application in either `program.cs` or `startup.cs` and either specifically or in a grouping with all the other actuators. All of these options can function effectively the same way, so this may be interpreted as a style choice.
 
 >Of all the options provided, the approach of using `AddAllActuators()` on the `HostBuilder` is most recommended.
 
@@ -59,9 +59,9 @@ using Steeltoe.Management.Endpoint;     // for other options
     }
     public static IHost BuildHost(string[] args) =>
         Host.CreateDefaultBuilder(args)
-            .AddCloudFoundryActuators() // add CF + security + others, deprecated in 3.1.0
-            .AddCloudFoundryActuator()  // add just CF + security
-            .AddAllActuators()          // add CF + security (when deployed to CF) and all others
+            .AddAllActuators()            // add CF + security (when deployed to CF) and all others
+            //.AddCloudFoundryActuators() // add CF + security + others, deprecated in 3.1.0
+            //.AddCloudFoundryActuator()  // add just CF + security
             .Build();
 ```
 
@@ -84,11 +84,13 @@ public class Startup
     public IConfiguration Configuration { get; }
     public void ConfigureServices(IServiceCollection services)
     {
-        // to add individual actuators one at a time
-        services.AddCloudFoundryActuator(Configuration);   // add just CF + security
-        // to add a group of actuators, choose ONE of the options below
-        services.AddCloudFoundryActuators(Configuration);  // add CF + security + others, deprecated in 3.1.0
-        services.AddAllActuators(Configuration);           // adds CF + security (when deployed to CF) and all others
+        // for versions >= 3.1.0-rc1, add all actuators and Cloud Foundry integration pieces
+        services.AddAllActuators(Configuration);
+
+        // for versions < 3.1.0, add all actuators and Cloud Foundry integration pieces
+        //services.AddCloudFoundryActuators(Configuration);
+        // if you prefer to add individual actuators
+        //services.AddCloudFoundryActuator(Configuration);
         ...    
     }
     public void Configure(IApplicationBuilder app)
@@ -103,8 +105,8 @@ public class Startup
         {
             endpoints.MapAllActuators()
         }
-
-        app.ApplicationServices.InitializeAvailability(); // Initializes health readiness and liveness probes
+        // Initializes health readiness and liveness probes
+        app.ApplicationServices.InitializeAvailability();
     }
 }
 ```

--- a/api/v3/welcome/index.md
+++ b/api/v3/welcome/index.md
@@ -1,53 +1,53 @@
 # Steeltoe Documentation
 
-## What's New in 3.0
+## [What's New in 3.0](./whats-new.md)
 
-## Application Configuration
+## [Application Configuration](../configuration/index.md)
 
 Steeltoe lets you store external configuration values in Git, the filesystem, or Hashicorp Vault with Spring Cloud Config.
 [read more](../configuration/index.md)
 
-## Circuit Breakers
+## [Circuit Breakers](../circuitbreaker/index.md)
 
 Steeltoe lets you use the Netflix Hystrix .NET implementation, a proven circuit breaker pattern with rich metrics and monitoring features.
 [read more](../circuitbreaker/index.md)
 
-## Distributed Tracing
+## [Distributed Tracing](../tracing/index.md)
 
 Steeltoe allows you to capture trace data for your microservice application using logs, or by sending it to a remote collector service.
 [read more](../tracing/index.md)
 
-## Dynamic Logging
+## [Dynamic Logging](../logging/index.md)
 
 Steeltoe adds a Logging provider to the set of available logging packages, to support the Steeltoe Management Logger endpoint.
 [read more](../logging/index.md)
 
-## Management
+## [Management](../management/index.md)
 
 Steeltoe lets you monitor and manage your application while it runs in production with Steeltoe management.
 [read more](../management/index.md)
 
-## Messaging
+## [Messaging](../messaging/index.md)
 
 Steeltoe allows you to automatically wire up and configure messaging in your application. Steeltoe messaging simplifies your configuration and significantly reduces boiler-plate code.
 [read more](../messaging/index.md)
 
-## Network File Sharing
+## [Network File Sharing](../fileshares/index.md)
 
 Steeltoe's WindowsNetworkFileShare provides a simplified experience for interacting with SMB file shares by making P/Invoke calls to underlying Windows APIs, specifically to mpr.dll.
 [read more](../fileshares/index.md)
 
-## Security
+## [Security](../security/index.md)
 
 Steeltoe lets you integrate ASP.NET authentication and authorization features in your app, no matter what platform you use.
 [read more](../security/index.md)
 
-## Service Connectors
+## [Service Connectors](../connectors/index.md)
 
 Steeltoe lets you automatically configure and manage connections to common cloud services like databases, caches, and more.
 [read more](../connectors/index.md)
 
-## Service Discovery
+## [Service Discovery](../discovery/index.md)
 
 Steeltoe includes .NET clients to both register and discover microservices in your registry of choice.
 [read more](../discovery/index.md)


### PR DESCRIPTION
- Add links to subpages from the v3 welcome page
- improve actuator CF integration page #121 
- add `_site` back to the .gitignore