### PR TITLE
Distributed Tracing Namespace

### DIFF
--- a/api/v2/tracing/index.md
+++ b/api/v2/tracing/index.md
@@ -99,9 +99,6 @@ Steeltoe distributed tracing handles this for you by default when using the .NET
 To enable distributed tracing all you need to to do is add the service to the container. To do this use the `AddDistributedTracing()` extension method from `TracingServiceCollectionExtensions`.
 
 ```csharp
-// Other Microsoft using statements...
-using Steeltoe.Management.Tracing
-
 public class Startup
 {
     public Startup(IConfiguration configuration)
@@ -115,6 +112,7 @@ public class Startup
     {
         ...
         // Add Distributed tracing
+        // Available through Steeltoe.Management.Tracing namespace
         services.AddDistributedTracing(Configuration);
 
         // Add framework services.

--- a/api/v2/tracing/index.md
+++ b/api/v2/tracing/index.md
@@ -48,7 +48,7 @@ To add this type of NuGet to your project, add a `PackageReference` resembling t
 ```xml
 <ItemGroup>
 ...
-    <PackageReference Include="Steeltoe.Management.TracingCore" Version="2.5.2" />
+    <PackageReference Include="Steeltoe.Management.TracingCore" Version="2.5.4" />
 ...
 </ItemGroup>
 ```
@@ -99,6 +99,9 @@ Steeltoe distributed tracing handles this for you by default when using the .NET
 To enable distributed tracing all you need to to do is add the service to the container. To do this use the `AddDistributedTracing()` extension method from `TracingServiceCollectionExtensions`.
 
 ```csharp
+// Other Microsoft using statements...
+using Steeltoe.Management.Tracing
+
 public class Startup
 {
     public Startup(IConfiguration configuration)

--- a/guides/cloud-management/distributed-tracing.md
+++ b/guides/cloud-management/distributed-tracing.md
@@ -33,6 +33,7 @@ Next, **create a .NET Core WebAPI** that interacts with Distributed Tracing
 1. Click **Generate Project** to download a zip containing the new project
 1. Extract the zipped project and open in your IDE of choice
 1. Add `Steeltoe.Management.TracingCore` NuGet package to your project
+
    ```xml
    <ItemGroup>
    ...
@@ -40,7 +41,9 @@ Next, **create a .NET Core WebAPI** that interacts with Distributed Tracing
    ...
    </ItemGroup>
    ```
+
 1. Add Distributed Tracing to your startup services
+
    ```csharp
    public void ConfigureServices(IServiceCollection services)
    {

--- a/guides/cloud-management/distributed-tracing.md
+++ b/guides/cloud-management/distributed-tracing.md
@@ -50,7 +50,7 @@ Next, **create a .NET Core WebAPI** that interacts with Distributed Tracing
       // Other service registrations...
 
       // Available through Steeltoe.Management.Tracing namespace
-      services.AddDistributedTracing();
+      services.AddDistributedTracingAspNetCore();
    }
    ```
 

--- a/guides/cloud-management/distributed-tracing.md
+++ b/guides/cloud-management/distributed-tracing.md
@@ -49,7 +49,7 @@ Next, **create a .NET Core WebAPI** that interacts with Distributed Tracing
    {
       // Other service registrations...
 
-      // Available with namespace Steeltoe.Management.Tracing
+      // Available through Steeltoe.Management.Tracing namespace
       services.AddDistributedTracing();
    }
    ```

--- a/guides/cloud-management/distributed-tracing.md
+++ b/guides/cloud-management/distributed-tracing.md
@@ -32,6 +32,24 @@ Next, **create a .NET Core WebAPI** that interacts with Distributed Tracing
 1. No dependency needs to be added
 1. Click **Generate Project** to download a zip containing the new project
 1. Extract the zipped project and open in your IDE of choice
+1. Add `Steeltoe.Management.TracingCore` NuGet package to your project
+   ```xml
+   <ItemGroup>
+   ...
+      <PackageReference Include="Steeltoe.Management.TracingCore" Version="3.1.0" />
+   ...
+   </ItemGroup>
+   ```
+1. Add Distributed Tracing to your startup services
+   ```csharp
+   public void ConfigureServices(IServiceCollection services)
+   {
+      // Other service registrations...
+
+      // Available with namespace Steeltoe.Management.Tracing
+      services.AddDistributedTracing();
+   }
+   ```
 
 **Run** the application
 


### PR DESCRIPTION
Fix for [MainSite Issue: Missing namespace for extension method in Distributed Tracing getting started](https://github.com/SteeltoeOSS/MainSite/issues/11)