### PR TITLE
app.UseDiscoveryClient() deprecated, update SCS links

### DIFF
--- a/api/v2/circuitbreaker/hystrix.md
+++ b/api/v2/circuitbreaker/hystrix.md
@@ -790,7 +790,9 @@ With Steeltoe, you can currently choose from two dashboards.
 
 The first is the [Netflix Hystrix Dashboard](https://github.com/Netflix/Hystrix/wiki/Dashboard). This dashboard is appropriate when you are not running your application on Cloud Foundry -- for example, when you are developing and testing your application locally on your desktop.
 
-The second is the [Spring Cloud Services Hystrix Dashboard](https://docs.pivotal.io/spring-cloud-services/1-5/common/circuit-breaker/). This dashboard is part of the [Spring Cloud Services](https://docs.pivotal.io/spring-cloud-services/1-5/common/) offering and is made available to applications through the normal service instance binding mechanisms on Cloud Foundry.
+The second is the [Spring Cloud Services Hystrix Dashboard](https://docs.pivotal.io/spring-cloud-services/2-1/common/circuit-breaker/index.html). This dashboard is part of the [Spring Cloud Services v2](https://docs.pivotal.io/spring-cloud-services/) offering and is made available to applications through the normal service instance binding mechanisms on Cloud Foundry.
+
+> As of Spring Cloud Services 3.0, the Hystrix Dashboard has been deprecated. The dashboard is still supported in version 2.1
 
 You should use the `Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore` package in an ASP.NET Core application when targeting the Netflix Hystrix Dashboard. When added to your app, it exposes a new REST endpoint in your application: `/hystrix/hystrix.stream`. This endpoint is used by the Netflix dashboard in receiving `SSE` metrics and status events from your application.
 

--- a/api/v2/configuration/config-server-provider.md
+++ b/api/v2/configuration/config-server-provider.md
@@ -168,7 +168,7 @@ public class Program
 
 ### Bind to Cloud Foundry
 
-When you want to use a Config Server on Cloud Foundry and you have installed [Spring Cloud Services](https://docs.pivotal.io/spring-cloud-services/1-5/common/index.html), you can create and bind an instance of it to your application by using the Cloud Foundry CLI, as follows:
+When you want to use a Config Server on Cloud Foundry and you have installed [Spring Cloud Services](https://docs.pivotal.io/spring-cloud-services/), you can create and bind an instance of it to your application by using the Cloud Foundry CLI, as follows:
 
 ```bash
 # Create config server instance named `myConfigServer`

--- a/api/v2/discovery/netflix-eureka.md
+++ b/api/v2/discovery/netflix-eureka.md
@@ -165,7 +165,7 @@ The samples and most templates are already set up to read from `appsettings.json
 
 ### Bind to Cloud Foundry
 
-When you want to use a Eureka Server on Cloud Foundry and you have installed [Spring Cloud Services](https://docs.pivotal.io/spring-cloud-services/1-5/common/index.html), you can create and bind a instance of the server to the application by using the Cloud Foundry CLI, as follows:
+When you want to use a Eureka Server on Cloud Foundry and you have installed [Spring Cloud Services](https://docs.pivotal.io/spring-cloud-services/), you can create and bind a instance of the server to the application by using the Cloud Foundry CLI, as follows:
 
 ```bash
 # Create eureka server instance named `myDiscoveryService`
@@ -181,7 +181,7 @@ cf bind-service myApp myDiscoveryService
 cf restage myApp
 ```
 
-For more information on using the Eureka Server on Cloud Foundry, see the [Spring Cloud Services](https://docs.pivotal.io/spring-cloud-services/1-5/common/index.html) documentation.
+For more information on using the Eureka Server on Cloud Foundry, see the [Spring Cloud Services](https://docs.pivotal.io/spring-cloud-services/) documentation.
 
 Once the service is bound to your application, the connection properties are available in `VCAP_SERVICES`.
 

--- a/api/v3/circuitbreaker/hystrix.md
+++ b/api/v3/circuitbreaker/hystrix.md
@@ -783,7 +783,9 @@ With Steeltoe, you can currently choose from two dashboards.
 
 The first is the [Netflix Hystrix Dashboard](https://github.com/Netflix/Hystrix/wiki/Dashboard). This dashboard is appropriate when you are not running your application on Cloud Foundry -- for example, when you are developing and testing your application locally on your desktop.
 
-The second is the [Spring Cloud Services Hystrix Dashboard](https://docs.pivotal.io/spring-cloud-services/1-5/common/circuit-breaker/). This dashboard is part of the [Spring Cloud Services](https://docs.pivotal.io/spring-cloud-services/1-5/common/) offering and is made available to applications through the normal service instance binding mechanisms on Cloud Foundry.
+The second is the [Spring Cloud Services Hystrix Dashboard](https://docs.pivotal.io/spring-cloud-services/1-5/common/circuit-breaker/). This dashboard is part of the [Spring Cloud Services v2](https://docs.pivotal.io/spring-cloud-services/) offering and is made available to applications through the normal service instance binding mechanisms on Cloud Foundry.
+
+> As of Spring Cloud Services 3.0, the Hystrix Dashboard has been deprecated. The dashboard is still supported in version 2.1
 
 You should use the `Steeltoe.CircuitBreaker.Hystrix.MetricsEventsCore` package in an ASP.NET Core application when targeting the Netflix Hystrix Dashboard. When added to your application, it exposes a new REST endpoint in your application: `/hystrix/hystrix.stream`. This endpoint is used by the Netflix dashboard in receiving `SSE` metrics and status events from your application.
 
@@ -868,7 +870,7 @@ cf create-service p-circuit-breaker-dashboard standard myHystrixService
 cf services
 ```
 
-For more information on using the Hystrix Dashboard on Cloud Foundry, see the [Spring Cloud Services](https://docs.pivotal.io/spring-cloud-services/1-4/common/) documentation.
+For more information on using the Hystrix Dashboard on Cloud Foundry, see the [Spring Cloud Services v2](https://docs.pivotal.io/spring-cloud-services/2-1/common/) documentation.
 
 Once the service is bound to your application, the settings are available in `VCAP_SERVICES`.
 

--- a/api/v3/configuration/config-server-provider.md
+++ b/api/v3/configuration/config-server-provider.md
@@ -156,7 +156,7 @@ public class Program
 
 ### Bind to Cloud Foundry
 
-When you want to use a Config Server on Cloud Foundry and you have installed [Spring Cloud Services](https://docs.pivotal.io/spring-cloud-services/1-5/common/index.html), you can create and bind an instance of it to your application by using the Cloud Foundry CLI, as follows:
+When you want to use a Config Server on Cloud Foundry and you have installed [Spring Cloud Services](https://docs.pivotal.io/spring-cloud-services/), you can create and bind an instance of it to your application by using the Cloud Foundry CLI, as follows:
 
 ```bash
 # Create config server instance named `myConfigServer`

--- a/api/v3/discovery/initialize-discovery-client.md
+++ b/api/v3/discovery/initialize-discovery-client.md
@@ -110,7 +110,8 @@ public class Startup {
         app.UseStaticFiles();
         app.UseMvc();
 
-        // Use the Steeltoe Discovery Client service
+        // Activate the Steeltoe Discovery Client service background thread
+        // This line is not needed for Steeltoe 3.1.0 and above
         app.UseDiscoveryClient();
     }
     ...

--- a/api/v3/discovery/netflix-eureka.md
+++ b/api/v3/discovery/netflix-eureka.md
@@ -86,7 +86,7 @@ For a complete understanding of the effects of many of these settings, we recomm
 
 ## Bind to Cloud Foundry
 
-When you want to use a Eureka Server on Cloud Foundry and you have installed [Spring Cloud Services](https://docs.pivotal.io/spring-cloud-services/1-5/common/index.html), you can create and bind an instance of the server to the application by using the Cloud Foundry CLI:
+When you want to use a Eureka Server on Cloud Foundry and you have installed [Spring Cloud Services](https://docs.pivotal.io/spring-cloud-services/), you can create and bind an instance of the server to the application by using the Cloud Foundry CLI:
 
 ```bash
 # Create eureka server instance named `myDiscoveryService`
@@ -102,7 +102,7 @@ cf bind-service myApp myDiscoveryService
 cf restage myApp
 ```
 
-For more information on using the Eureka Server on Cloud Foundry, see the [Spring Cloud Services](https://docs.pivotal.io/spring-cloud-services/1-5/common/index.html) documentation.
+For more information on using the Eureka Server on Cloud Foundry, see the [Spring Cloud Services](https://docs.pivotal.io/spring-cloud-services/) documentation.
 
 Once the service is bound to your application, the connection properties are available in `VCAP_SERVICES`.
 


### PR DESCRIPTION
- app.UseDiscoveryClient() is not needed in 3.1.0+
- updated links for SCS 
- added a note about Hystrix dashboard being deprecated