### PR TITLE
Enhance GitHub Actions

### DIFF
--- a/.github/workflows/stage-prod-swap.yml
+++ b/.github/workflows/stage-prod-swap.yml
@@ -17,6 +17,23 @@ jobs:
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
 
+    - name: Change mainsite link to prod and restart
+      shell: bash
+      run: |
+        az webapp config appsettings set --resource-group steeltoe --name docs-steeltoe --slot Staging --settings mainsite_host=https://steeltoe.io
+        az webapp restart --resource-group steeltoe --name docs-steeltoe --slot Staging
+        echo "Waiting 60 seconds until beginning to curl to see if the site is back up"
+        sleep 60
+        until $(curl --output /dev/null --silent --head --fail https://docs-staging.steeltoe.io); do
+          printf '.'
+          sleep 5
+        done
+
     - name: Swap slots
       run: az webapp deployment slot swap -s ${{ vars.STAGING_SLOT_NAME }} -n ${{ vars.AZURE_WEBAPP_NAME }} -g ${{ vars.AZURE_RESOURCE_GROUP }}
+
+    - name: Change mainsite link to staging and restart
+      run: |
+        az webapp config appsettings set --resource-group steeltoe --name docs-steeltoe --slot Staging --settings mainsite_host=https://staging.steeltoe.io
+        az webapp restart --resource-group steeltoe --name docs-steeltoe --slot Staging
     


### PR DESCRIPTION
Update the link to mainsite before and after performing a staging slot swap
Also waits 60 seconds (about how long before the app goes offline when updating the docker image) before starting a loop that curls every 5 seconds so we're sure the app is up before kicking it to the prod slot