### PR TITLE
Fix broken links

### DIFF
--- a/api/v2/circuitbreaker/hystrix.md
+++ b/api/v2/circuitbreaker/hystrix.md
@@ -37,7 +37,7 @@ To use the Steeltoe framework:
 * Use Hystrix Command(s) and/or Collapser(s) to invoke dependent services
 * Add and Use the Hystrix metrics stream service
 
->NOTE: Most of the code in the following sections is based on using Hystrix in an ASP.NET Core application. If you are developing an ASP.NET 4.x application or a Console based app, see the [other samples](https://github.com/SteeltoeOSS/Samples/tree/master/CircuitBreaker) for example code you can use.
+>NOTE: Most of the code in the following sections is based on using Hystrix in an ASP.NET Core application. If you are developing an ASP.NET 4.x application or a Console based app, see the [other samples](https://github.com/SteeltoeOSS/Samples/tree/2.x/CircuitBreaker) for example code you can use.
 
 ### Add NuGet References
 

--- a/api/v2/configuration/cloud-foundry-provider.md
+++ b/api/v2/configuration/cloud-foundry-provider.md
@@ -23,7 +23,7 @@ In order to use the Steeltoe Cloud Foundry provider you need to do the following
 1. Configure Cloud Foundry options classes by binding configuration data to the classes.
 1. Inject and use the Cloud Foundry Options to access Cloud Foundry configuration data.
 
->NOTE: Most of the example code in the following sections is based on using Steeltoe in an ASP.NET Core application. If you are developing an ASP.NET 4.x application or a Console based app, see the [other samples](https://github.com/SteeltoeOSS/Samples/tree/master/Configuration) for example code you can use.
+>NOTE: Most of the example code in the following sections is based on using Steeltoe in an ASP.NET Core application. If you are developing an ASP.NET 4.x application or a Console based app, see the [other samples](https://github.com/SteeltoeOSS/Samples/tree/2.x/Configuration) for example code you can use.
 
 ### Add NuGet Reference
 

--- a/api/v2/configuration/config-server-provider.md
+++ b/api/v2/configuration/config-server-provider.md
@@ -14,12 +14,12 @@ The Steeltoe Config Server provider supports the following .NET application type
 
 In addition to the Quick Start below, there are several other Steeltoe sample applications that you can refer to when needing help in understanding how to use this provider:
 
-* [AspDotNetCore/Simple](https://github.com/SteeltoeOSS/Samples/tree/master/Configuration/src/AspDotNetCore/Simple): ASP.NET Core sample app showing how to use the open source Config Server.
-* [AspDotNet4/Simple](https://github.com/SteeltoeOSS/Samples/tree/master/Configuration/src/AspDotNet4/Simple): Same as AspDotNetCore/Simple but built for ASP.NET 4.x
-* [AspDotNet4/SimpleCloudFoundry](https://github.com/SteeltoeOSS/Samples/tree/master/Configuration/src/AspDotNet4/SimpleCloudFoundry): Same as the Quick Start sample mentioned later but built for ASP.NET 4.x.
-* [AspDotNet4/AutofacCloudFoundry](https://github.com/SteeltoeOSS/Samples/tree/master/Configuration/src/AspDotNet4/AutofacCloudFoundry): Same as AspDotNet4/SimpleCloudFoundry but built using the Autofac IOC container.
-* [MusicStore](https://github.com/SteeltoeOSS/Samples/tree/master/MusicStore): A sample application showing how to use all of the Steeltoe components together in a ASP.NET Core application. This is a micro-services based application built from the ASP.NET Core MusicStore reference app provided by Microsoft.
-* [FreddysBBQ](https://github.com/SteeltoeOSS/Samples/tree/master/FreddysBBQ): A polyglot microservices-based sample app showing inter-operability between Java and .NET on Cloud Foundry. It is secured with OAuth2 Security Services and using Spring Cloud Services.
+* [AspDotNetCore/Simple](https://github.com/SteeltoeOSS/Samples/tree/2.x/Configuration/src/AspDotNetCore/Simple): ASP.NET Core sample app showing how to use the open source Config Server.
+* [AspDotNet4/Simple](https://github.com/SteeltoeOSS/Samples/tree/2.x/Configuration/src/AspDotNet4/Simple): Same as AspDotNetCore/Simple but built for ASP.NET 4.x
+* [AspDotNet4/SimpleCloudFoundry](https://github.com/SteeltoeOSS/Samples/tree/2.x/Configuration/src/AspDotNet4/SimpleCloudFoundry): Same as the Quick Start sample mentioned later but built for ASP.NET 4.x.
+* [AspDotNet4/AutofacCloudFoundry](https://github.com/SteeltoeOSS/Samples/tree/2.x/Configuration/src/AspDotNet4/AutofacCloudFoundry): Same as AspDotNet4/SimpleCloudFoundry but built using the Autofac IOC container.
+* [MusicStore](https://github.com/SteeltoeOSS/Samples/tree/2.x/MusicStore): A sample application showing how to use all of the Steeltoe components together in a ASP.NET Core application. This is a micro-services based application built from the ASP.NET Core MusicStore reference app provided by Microsoft.
+* [FreddysBBQ](https://github.com/SteeltoeOSS/Samples/tree/2.x/FreddysBBQ): A polyglot microservices-based sample app showing inter-operability between Java and .NET on Cloud Foundry. It is secured with OAuth2 Security Services and using Spring Cloud Services.
 
 >IMPORTANT: The `Pivotal.Extensions.Configuration.ConfigServer*` packages have been deprecated in Steeltoe 2.2 and are not included in future releases.  All functionality provided in those packages has been pushed into the corresponding `Steeltoe.Extensions.Configuration.ConfigServer*` packages.
 

--- a/api/v2/configuration/placeholder-provider.md
+++ b/api/v2/configuration/placeholder-provider.md
@@ -23,7 +23,7 @@ In order to use the Steeltoe Placeholder resolver provider you need to do the fo
 1. Optionally, configure Options classes by binding configuration data to the classes.
 1. Inject and use the Options classes or access configuration data directly.
 
->NOTE: Most of the example code in the following sections is based on using Steeltoe in an ASP.NET Core application. If you are developing an ASP.NET 4.x application or a Console based app, see the [other samples](https://github.com/SteeltoeOSS/Samples/tree/master/Configuration) for example code you can use.
+>NOTE: Most of the example code in the following sections is based on using Steeltoe in an ASP.NET Core application. If you are developing an ASP.NET 4.x application or a Console based app, see the [other samples](https://github.com/SteeltoeOSS/Samples/tree/2.x/Configuration) for example code you can use.
 
 ### Add NuGet Reference
 

--- a/api/v2/configuration/random-value-provider.md
+++ b/api/v2/configuration/random-value-provider.md
@@ -47,7 +47,7 @@ In order to use the Steeltoe RandomValue provider you need to do the following:
 1. Add the provider to the Configuration Builder.
 1. Access random values from the `IConfiguration`.
 
->NOTE: Most of the example code in the following sections is based on using Steeltoe in an ASP.NET Core application. If you are developing an ASP.NET 4.x application or a Console based app, see the [other samples](https://github.com/SteeltoeOSS/Samples/tree/master/Configuration) for example code you can use.
+>NOTE: Most of the example code in the following sections is based on using Steeltoe in an ASP.NET Core application. If you are developing an ASP.NET 4.x application or a Console based app, see the [other samples](https://github.com/SteeltoeOSS/Samples/tree/2.x/Configuration) for example code you can use.
 
 ### Add NuGet Reference
 

--- a/api/v2/connectors/mysql.md
+++ b/api/v2/connectors/mysql.md
@@ -9,9 +9,9 @@ Currently, the connector supports the following providers:
 
 Here are several Steeltoe sample applications to help you understand how to use this connector:
 
-* [AspDotNet4/MySql4](https://github.com/SteeltoeOSS/Samples/tree/master/Connectors/src/AspDotNet4/MySql4): Same as the next Quick Start but built for ASP.NET 4.x.
-* [MusicStore](https://github.com/SteeltoeOSS/Samples/tree/master/MusicStore): A sample app showing how to use all of the Steeltoe components together in a ASP.NET Core application. This is a micro-services based application built from the ASP.NET Core MusicStore reference app provided by Microsoft.
-* [FreddysBBQ](https://github.com/SteeltoeOSS/Samples/tree/master/FreddysBBQ): A polyglot (Java and .NET) micro-services based sample application showing interoperability between Java and .NET based micro-services running on Cloud Foundry, secured with OAuth2 Security Services, and using Spring Cloud Services.
+* [AspDotNet4/MySql4](https://github.com/SteeltoeOSS/Samples/tree/2.x/Connectors/src/AspDotNet4/MySql4): Same as the next Quick Start but built for ASP.NET 4.x.
+* [MusicStore](https://github.com/SteeltoeOSS/Samples/tree/2.x/MusicStore): A sample app showing how to use all of the Steeltoe components together in a ASP.NET Core application. This is a micro-services based application built from the ASP.NET Core MusicStore reference app provided by Microsoft.
+* [FreddysBBQ](https://github.com/SteeltoeOSS/Samples/tree/2.x/FreddysBBQ): A polyglot (Java and .NET) micro-services based sample application showing interoperability between Java and .NET based micro-services running on Cloud Foundry, secured with OAuth2 Security Services, and using Spring Cloud Services.
 
 This connector provides a `IHealthContributor` which you can use in conjunction with the [Steeltoe Management Health](/../management/health.html) check endpoint.
 

--- a/api/v2/connectors/redis.md
+++ b/api/v2/connectors/redis.md
@@ -5,8 +5,8 @@
 Here are some Steeltoe sample applications are available to help you understand how to use this connector:
 
 * [AspDotNet4/Redis4](https://github.com/SteeltoeOSS/Samples/tree/dev/Connectors/src/AspDotNet4/Redis4): Same as the next Quick Start but built for ASP.NET 4.x.
-* [DataProtection](https://github.com/SteeltoeOSS/Samples/tree/master/Security/src/RedisDataProtectionKeyStore): A sample application showing how to use the Steeltoe DataProtection Key Storage Provider for Redis.
-* [MusicStore](https://github.com/SteeltoeOSS/Samples/tree/master/MusicStore): A sample application showing how to use all of the Steeltoe components together in an ASP.NET Core application. This is a micro-services based application built from the ASP.NET Core reference app MusicStore provided by Microsoft.
+* [DataProtection](https://github.com/SteeltoeOSS/Samples/tree/2.x/Security/src/RedisDataProtectionKeyStore): A sample application showing how to use the Steeltoe DataProtection Key Storage Provider for Redis.
+* [MusicStore](https://github.com/SteeltoeOSS/Samples/tree/2.x/MusicStore): A sample application showing how to use all of the Steeltoe components together in an ASP.NET Core application. This is a micro-services based application built from the ASP.NET Core reference app MusicStore provided by Microsoft.
 
 This connector provides a `IHealthContributor` which you can use in conjunction with the [Steeltoe Management Health](/../management/health.html) check endpoint.
 

--- a/api/v2/discovery/hashicorp-consul.md
+++ b/api/v2/discovery/hashicorp-consul.md
@@ -24,7 +24,7 @@ In order to use the Steeltoe Discovery client, you need to do the following:
 * Add and Use the Discovery client service in the application.
 * Use an injected `IDiscoveryClient` to lookup services.
 
->NOTE: Most of the example code in the following sections is based on using Discovery in a ASP.NET Core application. If you are developing a ASP.NET 4.x application or a console-based app, see the [other samples](https://github.com/SteeltoeOSS/Samples/tree/master/Discovery) for example code you can use.
+>NOTE: Most of the example code in the following sections is based on using Discovery in a ASP.NET Core application. If you are developing a ASP.NET 4.x application or a console-based app, see the [other samples](https://github.com/SteeltoeOSS/Samples/tree/2.x/Discovery) for example code you can use.
 
 ### Consul Settings
 

--- a/api/v2/discovery/netflix-eureka.md
+++ b/api/v2/discovery/netflix-eureka.md
@@ -10,10 +10,10 @@ The Eureka client implementation supports the following .NET application types:
 
 Here are several Steeltoe sample applications when looking for help in understanding how to use this client:
 
-* [AspDotNet4/Fortune-Teller-Service4](https://github.com/SteeltoeOSS/Samples/tree/master/Discovery/src/AspDotNet4/Fortune-Teller-Service4): Same as the Quick Start next but built for ASP.NET 4.x and using the Autofac IOC container.
-* [AspDotNet4/Fortune-Teller-UI4](https://github.com/SteeltoeOSS/Samples/tree/master/Discovery/src/AspDotNet4/Fortune-Teller-UI4): Same as the Quick Start next but built for ASP.NET 4.x and using the Autofac IOC container
-* [MusicStore](https://github.com/SteeltoeOSS/Samples/tree/master/MusicStore): A sample application showing how to use all of the Steeltoe components together in a ASP.NET Core application. This is a microservices-based application built from the ASP.NET Core MusicStore reference app provided by Microsoft.
-* [FreddysBBQ](https://github.com/SteeltoeOSS/Samples/tree/master/FreddysBBQ): A polyglot microservices-based sample application showing interoperability between Java and .NET on Cloud Foundry. It is secured with OAuth2 Security Services and using Spring Cloud Services.
+* [AspDotNet4/Fortune-Teller-Service4](https://github.com/SteeltoeOSS/Samples/tree/2.x/Discovery/src/AspDotNet4/Fortune-Teller-Service4): Same as the Quick Start next but built for ASP.NET 4.x and using the Autofac IOC container.
+* [AspDotNet4/Fortune-Teller-UI4](https://github.com/SteeltoeOSS/Samples/tree/2.x/Discovery/src/AspDotNet4/Fortune-Teller-UI4): Same as the Quick Start next but built for ASP.NET 4.x and using the Autofac IOC container
+* [MusicStore](https://github.com/SteeltoeOSS/Samples/tree/2.x/MusicStore): A sample application showing how to use all of the Steeltoe components together in a ASP.NET Core application. This is a microservices-based application built from the ASP.NET Core MusicStore reference app provided by Microsoft.
+* [FreddysBBQ](https://github.com/SteeltoeOSS/Samples/tree/2.x/FreddysBBQ): A polyglot microservices-based sample application showing interoperability between Java and .NET on Cloud Foundry. It is secured with OAuth2 Security Services and using Spring Cloud Services.
 
 ## Usage
 
@@ -31,7 +31,7 @@ In order to use the Steeltoe Discovery client, you need to do the following:
 * Add and Use the Discovery client service in the application.
 * Use an injected `IDiscoveryClient` to lookup services.
 
->NOTE: Most of the example code in the following sections is based on using Discovery in a ASP.NET Core application. If you are developing a ASP.NET 4.x application or a console-based app, see the [other samples](https://github.com/SteeltoeOSS/Samples/tree/master/Discovery) for example code you can use.
+>NOTE: Most of the example code in the following sections is based on using Discovery in a ASP.NET Core application. If you are developing a ASP.NET 4.x application or a console-based app, see the [other samples](https://github.com/SteeltoeOSS/Samples/tree/2.x/Discovery) for example code you can use.
 
 ### Eureka Settings
 

--- a/api/v2/management/info.md
+++ b/api/v2/management/info.md
@@ -13,7 +13,7 @@ The following table describes the `IInfoContributor` implementations provided by
 | `AppSettingsInfoContributor`|Exposes any values under the key `info` (for example, `info:foo:bar=foobar`) that is in your apps configuration (for example, `appsettings.json`)|
 | `GitInfoContributor`|Exposes git information (if a git.properties file is available)|
 
-For an example of how to use the above `GitInfoContributor` within MSBuild using [GitInfo](https://github.com/kzu/GitInfo), see the [Steeltoe management sample](https://github.com/SteeltoeOSS/Samples/tree/master/Management/src/AspDotNetCore/CloudFoundry) and the [CloudFoundry.csproj](https://github.com/SteeltoeOSS/Samples/blob/master/Management/src/AspDotNetCore/CloudFoundry/CloudFoundry.csproj) file.
+For an example of how to use the above `GitInfoContributor` within MSBuild using [GitInfo](https://github.com/kzu/GitInfo), see the [Steeltoe management sample](https://github.com/SteeltoeOSS/Samples/tree/2.x/Management/src/AspDotNetCore/CloudFoundry) and the [CloudFoundry.csproj](https://github.com/SteeltoeOSS/Samples/blob/master/Management/src/AspDotNetCore/CloudFoundry/CloudFoundry.csproj) file.
 
 If you wish to provide custom information for your application, create a class that implements the `IInfoContributor` interface and then add that to the `InfoEndpoint`. Details on how to add a contributor to the endpoint is provided below.
 

--- a/api/v3/configuration/config-server-provider.md
+++ b/api/v3/configuration/config-server-provider.md
@@ -8,9 +8,9 @@ To gain a better understanding of the Spring Cloud Config Server, you should rea
 
 In addition to the Quick Start provided later, you can refer to several other Steeltoe sample applications when you need to understand how to use this provider:
 
-* [AspDotNetCore/Simple](https://github.com/SteeltoeOSS/Samples/tree/master/Configuration/src/Simple): ASP.NET Core sample application showing how to use the open source Config Server.
-* [MusicStore](https://github.com/SteeltoeOSS/Samples/tree/master/MusicStore): A sample application showing how to use all of the Steeltoe components together in a ASP.NET Core application. This is a microservices based application built from the ASP.NET Core MusicStore reference app provided by Microsoft.
-* [FreddysBBQ](https://github.com/SteeltoeOSS/Samples/tree/master/FreddysBBQ): A polyglot microservices-based sample application showing inter-operability between Java and .NET on Cloud Foundry. It is secured with OAuth2 Security Services and uses Spring Cloud Services.
+* [AspDotNetCore/Simple](https://github.com/SteeltoeOSS/Samples/tree/3.x/Configuration/src/Simple): ASP.NET Core sample application showing how to use the open source Config Server.
+* [MusicStore](https://github.com/SteeltoeOSS/Samples/tree/3.x/MusicStore): A sample application showing how to use all of the Steeltoe components together in a ASP.NET Core application. This is a microservices based application built from the ASP.NET Core MusicStore reference app provided by Microsoft.
+* [FreddysBBQ](https://github.com/SteeltoeOSS/Samples/tree/3.x/FreddysBBQ): A polyglot microservices-based sample application showing inter-operability between Java and .NET on Cloud Foundry. It is secured with OAuth2 Security Services and uses Spring Cloud Services.
 
 ## Usage
 

--- a/api/v3/connectors/mysql.md
+++ b/api/v3/connectors/mysql.md
@@ -9,8 +9,8 @@ Currently, the connector supports the following providers:
 
 The following Steeltoe sample applications can help you understand how to use this connector:
 
-* [MusicStore](https://github.com/SteeltoeOSS/Samples/tree/master/MusicStore): A sample application showing how to use all of the Steeltoe components together in a ASP.NET Core application. This is a microservices based application built from the ASP.NET Core MusicStore reference app provided by Microsoft.
-* [FreddysBBQ](https://github.com/SteeltoeOSS/Samples/tree/master/FreddysBBQ): A polyglot (Java and .NET) microservices-based sample application showing interoperability between Java- and .NET-based microservices running on Cloud Foundry, secured with OAuth2 Security Services and using Spring Cloud Services.
+* [MusicStore](https://github.com/SteeltoeOSS/Samples/tree/3.x/MusicStore): A sample application showing how to use all of the Steeltoe components together in a ASP.NET Core application. This is a microservices based application built from the ASP.NET Core MusicStore reference app provided by Microsoft.
+* [FreddysBBQ](https://github.com/SteeltoeOSS/Samples/tree/3.x/FreddysBBQ): A polyglot (Java and .NET) microservices-based sample application showing interoperability between Java- and .NET-based microservices running on Cloud Foundry, secured with OAuth2 Security Services and using Spring Cloud Services.
 
 This connector provides a `IHealthContributor` object, which you can use in conjunction with the [Steeltoe Management Health](../management/health.md) check endpoint.
 

--- a/api/v3/connectors/redis.md
+++ b/api/v3/connectors/redis.md
@@ -4,8 +4,8 @@ This connector simplifies using a Microsoft [`RedisCache`](https://docs.microsof
 
 The following Steeltoe sample applications are available to help you understand how to use this connector:
 
-* [DataProtection](https://github.com/SteeltoeOSS/Samples/tree/master/Security/src/RedisDataProtectionKeyStore): A sample application showing how to use the Steeltoe DataProtection Key Storage Provider for Redis.
-* [MusicStore](https://github.com/SteeltoeOSS/Samples/tree/master/MusicStore): A sample application showing how to use all of the Steeltoe components together in an ASP.NET Core application. This is a microservices-based application built from the  MusicStore ASP.NET Core reference application provided by Microsoft.
+* [DataProtection](https://github.com/SteeltoeOSS/Samples/tree/3.x/Security/src/RedisDataProtectionKeyStore): A sample application showing how to use the Steeltoe DataProtection Key Storage Provider for Redis.
+* [MusicStore](https://github.com/SteeltoeOSS/Samples/tree/3.x/MusicStore): A sample application showing how to use all of the Steeltoe components together in an ASP.NET Core application. This is a microservices-based application built from the  MusicStore ASP.NET Core reference application provided by Microsoft.
 
 This connector provides an `IHealthContributor`, which you can use in conjunction with the [Steeltoe Management Health](../management/health.md) check endpoint.
 

--- a/api/v3/connectors/usage.md
+++ b/api/v3/connectors/usage.md
@@ -140,4 +140,4 @@ builder.Configuration.AddKubernetesServiceBindings();
 
 ### Additional Resources
 
-To see the binding support in action, review the [Steeltoe PostgreSql EF Core Connector sample](https://github.com/SteeltoeOSS/Samples/tree/main/Connectors/src/PostgreSqlEFCore).
+To see the binding support in action, review the [Steeltoe PostgreSql EF Core Connector sample](https://github.com/SteeltoeOSS/Samples/tree/3.x/Connectors/src/PostgreSqlEFCore).

--- a/api/v3/discovery/netflix-eureka.md
+++ b/api/v3/discovery/netflix-eureka.md
@@ -4,8 +4,8 @@ The Eureka client implementation lets applications register services with a Eure
 
 In addition to the Quick Start below, the following Steeltoe sample applications may help you to understand how to use this client:
 
-* [MusicStore](https://github.com/SteeltoeOSS/Samples/tree/master/MusicStore): A sample application showing how to use all of the Steeltoe components together in a ASP.NET Core application. This is a microservices-based application built from the ASP.NET Core MusicStore reference app provided by Microsoft.
-* [FreddysBBQ](https://github.com/SteeltoeOSS/Samples/tree/master/FreddysBBQ): A polyglot microservices-based sample application showing interoperability between Java and .NET on Cloud Foundry. It is secured with OAuth2 Security Services and uses Spring Cloud Services.
+* [MusicStore](https://github.com/SteeltoeOSS/Samples/tree/3.x/MusicStore): A sample application showing how to use all of the Steeltoe components together in a ASP.NET Core application. This is a microservices-based application built from the ASP.NET Core MusicStore reference app provided by Microsoft.
+* [FreddysBBQ](https://github.com/SteeltoeOSS/Samples/tree/3.x/FreddysBBQ): A polyglot microservices-based sample application showing interoperability between Java and .NET on Cloud Foundry. It is secured with OAuth2 Security Services and uses Spring Cloud Services.
 
 ## Eureka Settings
 

--- a/api/v3/logging/serilog-logger.md
+++ b/api/v3/logging/serilog-logger.md
@@ -4,7 +4,7 @@ This logging provider extends the dynamic logging provider with [Serilog](https:
 
 The source code for the Serilog Dynamic Logger can be found [here](https://github.com/SteeltoeOSS/steeltoe/tree/master/src/Logging/src/).
 
-A sample working project can be found [here](https://github.com/SteeltoeOSS/Samples/tree/master/Management/src/CloudFoundry).
+A sample working project can be found [here](https://github.com/SteeltoeOSS/Samples/tree/3.x/Management/src/CloudFoundry).
 
 ## Usage
 

--- a/api/v3/management/health.md
+++ b/api/v3/management/health.md
@@ -281,4 +281,4 @@ public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerF
 }
 ```
 
-A complete example is available [here](https://github.com/SteeltoeOSS/Samples/tree/master/Management/src/AspDotNetCore/MicrosoftHealthChecks).
+A complete example is available [here](https://github.com/SteeltoeOSS/Samples/tree/3.x/Management/src/AspDotNetCore/MicrosoftHealthChecks).

--- a/api/v3/management/info.md
+++ b/api/v3/management/info.md
@@ -14,7 +14,7 @@ The following table describes the `IInfoContributor` implementations provided by
 | `BuildInfoContributor` | Exposes file/version info for both the included version of Steeltoe and the application. |
 | `GitInfoContributor` | Exposes git information (if a `git.properties` file is available). |
 
-For an example of how to use the above `GitInfoContributor` within MSBuild using [GitInfo](https://github.com/kzu/GitInfo), see the [Steeltoe management sample](https://github.com/SteeltoeOSS/Samples/tree/master/Management/src/AspDotNetCore/CloudFoundry) and the [CloudFoundry.csproj](https://github.com/SteeltoeOSS/Samples/blob/master/Management/src/AspDotNetCore/CloudFoundry/CloudFoundry.csproj) file.
+For an example of how to use the above `GitInfoContributor` within MSBuild using [GitInfo](https://github.com/kzu/GitInfo), see the [Steeltoe management sample](https://github.com/SteeltoeOSS/Samples/tree/3.x/Management/src/AspDotNetCore/CloudFoundry) and the [CloudFoundry.csproj](https://github.com/SteeltoeOSS/Samples/blob/master/Management/src/AspDotNetCore/CloudFoundry/CloudFoundry.csproj) file.
 
 If you wish to provide custom information for your application, create a class that implements the `IInfoContributor` interface and then add that to the `InfoEndpoint`. Details on how to add a contributor to the endpoint is provided later in this section.
 

--- a/api/v3/management/using-endpoints.md
+++ b/api/v3/management/using-endpoints.md
@@ -205,4 +205,4 @@ When using the `IHostBuilder` extensions, it can be added as shown:
 
 When called without arguments, the default profile is used. Other overloads allow passing a profile or a profile name.
 
-A complete example is available here [here](https://github.com/SteeltoeOSS/Samples/tree/master/Management/src/SecureEndpoints).
+A complete example is available here [here](https://github.com/SteeltoeOSS/Samples/tree/3.x/Management/src/SecureEndpoints).

--- a/api/v3/messaging/rabbitmq-intro.md
+++ b/api/v3/messaging/rabbitmq-intro.md
@@ -365,7 +365,7 @@ The latter is the mechanism used when retries are enabled and the maximum number
 The Steeltoe RabbitMQHost extends the Microsoft Generic Host and provides for auto configuration of Steeltoe RabbitMQ services.
 
 > [!NOTE]
-> For more detailed examples of using the RabbitMQ Host, please refer to the [Messaging](https://github.com/SteeltoeOSS/Samples/tree/main/Messaging/src) solutions in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
+> For more detailed examples of using the RabbitMQ Host, please refer to the [Messaging](https://github.com/SteeltoeOSS/Samples/tree/3.x/Messaging/src) solutions in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
 
 Below are two code snippets within `Program.cs` and `Startup.cs` that demonstrate the usage of RabbitMQHost:
 

--- a/api/v3/stream/data-flow-stream.md
+++ b/api/v3/stream/data-flow-stream.md
@@ -32,7 +32,7 @@ In this guide, we describe how you can register these Steeltoe based components 
 
 ## Development
 
-The [samples repo](https://github.com/SteeltoeOSS/Samples/tree/main/Stream) has a number of Steeltoe Stream sample applications. For this example we will be using the `CloudDataFlowLogToUpperProcessor` sample, which implements an `IProcessor` interface and the `CloudDataFlowLogSink` sample, which implements an `ISink` interface.
+The [samples repo](https://github.com/SteeltoeOSS/Samples/tree/3.x/Stream) has a number of Steeltoe Stream sample applications. For this example we will be using the `CloudDataFlowLogToUpperProcessor` sample, which implements an `IProcessor` interface and the `CloudDataFlowLogSink` sample, which implements an `ISink` interface.
 For an `ISource` use the `HttpSource` application available at `maven://org.springframework.cloud.stream.app:http-source-rabbit:3.0.1`
 
 Spring Cloud team publishes a number of sample applications as `maven` and `docker` artifacts at the `https://repo.spring.io` Maven repository. These pre-packaged applications can be used with Steeltoe Stream.

--- a/api/v3/stream/stream-reference.md
+++ b/api/v3/stream/stream-reference.md
@@ -1345,7 +1345,7 @@ Applications can do so by using the `BinderAwareChannelResolver` service (which 
 The `spring.cloud.stream.dynamicDestinations` setting can be used for restricting the dynamic destination names to a known set (whitelisting).
 If this property is not set, any destination can be bound dynamically.
 
-The `BinderAwareChannelResolver` can be used directly, as shown in the following example of a console application receiving messages from an input source and deciding the target channel based on the body of the message (see [Dynamic Destination Sample](https://github.com/SteeltoeOSS/Samples/tree/main/Stream/DynamicDestinationMessaging) for full solution):
+The `BinderAwareChannelResolver` can be used directly, as shown in the following example of a console application receiving messages from an input source and deciding the target channel based on the body of the message (see [Dynamic Destination Sample](https://github.com/SteeltoeOSS/Samples/tree/3.x/Stream/DynamicDestinationMessaging) for full solution):
 
 Program.cs
 

--- a/articles/releases/steeltoe-3-0-packs-a-mighty-punch-with-many-new-features.md
+++ b/articles/releases/steeltoe-3-0-packs-a-mighty-punch-with-many-new-features.md
@@ -31,9 +31,7 @@ Steeltoe makes things like production ready database connections a single line o
 
 Steeltoe 3.0 is a product of years of learning. Small businesses and large enterprises have all been benefiting and contributing to this new release. It’s a fresh take on cloud opinions that seemingly never get answered. It’s the next evolution for your microservices to go to cloud ninja status.
 
----
-##### If you’re moving from Steeltoe 2.x and would like a quick comparision with version 3.0, refer to [this page](https://steeltoe.io/docs/3/welcome/whats-new).
----
+> If you’re moving from Steeltoe 2.x and would like a quick comparison with version 3.0, refer to [this page](https://docs.steeltoe.io/api/v3/welcome/whats-new.html).
 
 Let's take a look at the new things included in Steeltoe 3.0. If you’re still wondering how the project fits in your new or existing .NET applications, [learn how here](https://steeltoe.io).
 
@@ -43,7 +41,7 @@ You might know it as a few different things - eventing, event architecture, even
 
 To help developers use message based systems but not have to manage all the debt that typically comes along with such a thing, Steeltoe 3 introduces the new Messaging component. This component does all the work of resiliency, portability, and fault-tolerance. To implement it you provide the location of the message server and start reading & writing messages. Want to include a custom object in the message? Steeltoe Messaging will take care of converting the bytes. Should the queue be "ensured" when the application is starting up? Configure Steeltoe Messaging to create it, if nothing is present. Do you have potentially many instances of an application that all share the same queue? Steeltoe Messaging will handle everything appropriately for you.
 
-To get started using Messaging ([here is a full example](https://github.com/SteeltoeOSS/Samples/tree/master/Messaging)), provide the server address in `appsettings.json`:
+To get started using Messaging ([here is a full example](https://github.com/SteeltoeOSS/Samples/tree/3.x/Messaging)), provide the server address in `appsettings.json`:
 
 ```json
 "Spring": {
@@ -55,13 +53,17 @@ To get started using Messaging ([here is a full example](https://github.com/Stee
   }
 }
 ```
+
 Then using dependency injection, send a message to the queue:
+
 ```csharp
 public MyService(RabbitTemplate amqpTemplate, MyCustomObject myObj) {
         amqpTemplate.ConvertAndSend("myqueue", myObj);
 }
 ```
+
 Receive messages in a registered callback, managed by Steeltoe and the Rabbit broker:
+
 ```csharp
 [RabbitListener("myqueue")]
 public void Listen(MyCustomObject myObj){
@@ -69,7 +71,7 @@ public void Listen(MyCustomObject myObj){
 }
 ```
 
-Once you’ve got the basics down, it’s time to extend and make the design better with things like custom factories. Steeltoe Messaging will take care of the conversion of a message into a structured type but sometimes you want to intercept that conversion and make decisions. You can create your own `DirectRabbitListenerContainer` and customize to your heart's content. Learn more about custom listener container factories [in the docs](https://dev.steeltoe.io/docs/3/messaging/rabbitmq-intro#basics).
+Once you’ve got the basics down, it’s time to extend and make the design better with things like custom factories. Steeltoe Messaging will take care of the conversion of a message into a structured type but sometimes you want to intercept that conversion and make decisions. You can create your own `DirectRabbitListenerContainer` and customize to your heart's content. Learn more about custom listener container factories [in the docs](https://docs.steeltoe.io/api/v3/messaging/rabbitmq-intro.html#basics).
 
 ## Legacy and Modern together in the cloud
 
@@ -87,7 +89,7 @@ The Steeltoe team has begun the journey of supporting K8s specific things with t
 
 Adding to the list of supported service registries, Steeltoe now offers developers the option of using native Kubernetes. The really amazing design of this is, there are no additional dependencies to be deployed. Registration and discovery can happen with the resources already provided in every cluster.
 
-In Kubernetes, when you want an application registered as discoverable, no work is required. To discover services, simply include the `Steeltoe.Discovery.ClientCore` and `Steeltoe.Discovery.Kubernetes` packages along with implementing the discovery client in the `HostBuilder` ([here is a full example](https://github.com/SteeltoeOSS/Samples/tree/master/Discovery/src)).
+In Kubernetes, when you want an application registered as discoverable, no work is required. To discover services, simply include the `Steeltoe.Discovery.ClientCore` and `Steeltoe.Discovery.Kubernetes` packages along with implementing the discovery client in the `HostBuilder` ([here is a full example](https://github.com/SteeltoeOSS/Samples/tree/3.x/Discovery/src)).
 
 ```csharp
 public static IHostBuilder CreateHostBuilder(string[] args) =>
@@ -117,7 +119,7 @@ Now when an new request is created using the http client `var result = await _ht
 
 Kubernetes also has powerful built in features when it comes to getting configuration settings into an application. Combine that with the power of .NET Core’s configuration provider hierarchy and you have one heck of a cloud-native application.
 
-Let's say we have the following ConfigMap ([here is a full example](https://github.com/SteeltoeOSS/Samples/tree/master/Configuration/src/Kubernetes)):
+Let's say we have the following ConfigMap ([here is a full example](https://github.com/SteeltoeOSS/Samples/tree/3.x/Configuration/src/Kubernetes)):
 
 ```yaml
 apiVersion: v1
@@ -139,7 +141,9 @@ public static IHostBuilder CreateHostBuilder(string[] args) =>
     })
     .AddKubernetesConfiguration();
 ```
+
 And then retrieve the configuration value through IConfiguration dependency injection:
+
 ```csharp
 public HomeController(IConfiguration config) {
   string myKey = config["someKey"];
@@ -156,9 +160,7 @@ The Initializr project aims to solve a very common challenge in every organizati
 
 Not only does this save the developer from writing code to manage config server connections or health endpoints or any other essential of microservices, it also keeps their projects on the latest patched libraries.
 
----
-##### Learn more about Initializr [now](https://steeltoe.io/initializr)
----
+> Learn more about Initializr [now](https://steeltoe.io/initializr)
 
 When you review the available dependencies in Steeltoe’s hosted version of Initializr you are probably going to have the need to add your own custom dependencies or want to bring the whole tool in-house. That is one of Initializr’s super powers!
 
@@ -170,10 +172,10 @@ One of the most shocking things to a developer that is new to working with conta
 
 Observability is typically a sum of logs, traces, and metrics. Sometimes you have them all and sometimes not. Sometimes the data is all on one dashboard and (most of the time) it’s distributed between 2 or more dashboards. Regardless of where the data is being observed, a developer should not have to bring in all kinds of custom dependencies to conform to each dashboard used. They should offer the information in a simple, neutral way with little time spent getting it all wired up.
 
-Steeltoe 3.0 continues the management endpoints found in 2.x but takes things to a deeper place. Along with the following examples, you can also get started using Tanzu Observability with Wavefront or create a Grafana dashboard in our [observability guides](https://dev.steeltoe.io/observability).
+Steeltoe 3.0 continues the management endpoints found in 2.x but takes things to a deeper place. Along with the following examples, you can also get started using Tanzu Observability with Wavefront or create a Grafana dashboard in our [observability guides](https://docs.steeltoe.io/guides/observability/grafana.html).
 
 * Originally OpenCensus was used for creating standard trace data and metrics. That has been superseded by the OpenTelemetry telemetric standard.
-* Creating tracing spans has been simplified to a single line in `startup.cs` ([here is a full example](https://github.com/SteeltoeOSS/Samples/tree/master/Management/src/Tracing))
+* Creating tracing spans has been simplified to a single line in `startup.cs` ([here is a full example](https://github.com/SteeltoeOSS/Samples/tree/3.x/Management/src/Tracing))
 
   ```csharp
   public void ConfigureServices(IServiceCollection services) {
@@ -183,7 +185,7 @@ Steeltoe 3.0 continues the management endpoints found in 2.x but takes things to
   }
   ```
 
-* In addition to the [metrics endpoint](https://dev.steeltoe.io/docs/3/management/metrics-observers), there is a new prometheus endpoint that offers a simple way for metrics to be scraped. Below is an example prometheus.yml configuration ([here is a full example](https://github.com/SteeltoeOSS/Samples/tree/master/Management/src)):
+* In addition to the [metrics endpoint](https://docs.steeltoe.io/api/v3/management/metrics.html), there is a new Prometheus endpoint that offers a simple way for metrics to be scraped. Below is an example prometheus.yml configuration ([here is a full example](https://github.com/SteeltoeOSS/Samples/tree/3.x/Management/src)):
 
   ```yaml
   scrape_configs:
@@ -192,7 +194,7 @@ Steeltoe 3.0 continues the management endpoints found in 2.x but takes things to
       scrape_interval: 5s
   ```
 
-* [Dynamic logging](https://dev.steeltoe.io/docs/3/logging) can be implemented with a single statement in the `HostBuilder`
+* [Dynamic logging](https://docs.steeltoe.io/api/v3/logging/) can be implemented with a single statement in the `HostBuilder`
 
     ```csharp
     public static IHostBuilder CreateHostBuilder(string[] args) =>
@@ -203,7 +205,7 @@ Steeltoe 3.0 continues the management endpoints found in 2.x but takes things to
         .AddDynamicLogging();
   ```
 
-* To use Spring Boot Admin as your management dashboard add the following to `appsettings.json` ([here is a full example](https://github.com/SteeltoeOSS/Samples/tree/master/Management/src/SpringBootAdmin)):
+* To use Spring Boot Admin as your management dashboard add the following to `appsettings.json` ([here is a full example](https://github.com/SteeltoeOSS/Samples/tree/3.x/Management/src/SpringBootAdmin)):
 
   ```json
   "spring": {
@@ -216,7 +218,9 @@ Steeltoe 3.0 continues the management endpoints found in 2.x but takes things to
       }
     }
   ```
+
   And implement the client in Startup.cs
+
   ```csharp
   public void Configure(IApplicationBuilder app) {
     ...
@@ -235,6 +239,7 @@ Steeltoe still has much love for Cloud Foundry but you’re going to see a lot m
 Here are a few examples of new ways to implement things in the `HostBuilder`:
 
 * Initialize only the health and dynamic logging
+
   ```csharp
   public static IHostBuilder CreateHostBuilder(string[] args) =>
     Host.CreateDefaultBuilder(args)
@@ -246,6 +251,7 @@ Here are a few examples of new ways to implement things in the `HostBuilder`:
   ```
 
 * Initialize all actuators and optionally secure them behind an authorization policy
+
   ```csharp
   public static IHostBuilder CreateHostBuilder(string[] args) =>
     Host.CreateDefaultBuilder(args)
@@ -257,6 +263,7 @@ Here are a few examples of new ways to implement things in the `HostBuilder`:
   ```
 
 * To instantly enable the enhanced features of app manager in Tanzu Application Services
+
   ```csharp
   public static IHostBuilder CreateHostBuilder(string[] args) =>
     Host.CreateDefaultBuilder(args)

--- a/articles/steeltoe-3-2-2-adds-kube-service-bindings.md
+++ b/articles/steeltoe-3-2-2-adds-kube-service-bindings.md
@@ -107,7 +107,7 @@ As an added feature, the Steeltoe team has added integration with the [Steeltoe 
 }
 ```
 
-Take a look at the Steeltoe [PostgreSql Connector sample](https://github.com/SteeltoeOSS/Samples/tree/main/Connectors/src/PostgreSql) for more details.
+Take a look at the Steeltoe [PostgreSql Connector sample](https://github.com/SteeltoeOSS/Samples/tree/3.x/Connectors/src/PostgreSql) for more details.
 
 The Steeltoe team is excited to hear your thoughts and opinions on this latest release. Remember you can join us on the Steeltoe Community call or reach out to the team directly on the [Steeltoe Slack](https://steeltoeteam.slack.com//).
 

--- a/articles/tech-tutorial-use-kubernetes-for-modern-net-apps-steeltoe-and-project-tye-are-your-path-to-productivity.md
+++ b/articles/tech-tutorial-use-kubernetes-for-modern-net-apps-steeltoe-and-project-tye-are-your-path-to-productivity.md
@@ -44,7 +44,7 @@ Further, configuration values come from different sources in different environme
 
 .NET Core introduced [configuration providers](https://docs.microsoft.com/aspnet/core/fundamentals/configuration/?view=aspnetcore-3.1#configuration-providers) and a hierarchy to them. So it's natural that a Kubernetes configmap (which is just another key/value store) should be a config source in a .NET microservice.
 
-[Steeltoe offers a Kubernetes provider](https://steeltoe.io/docs/3/configuration/kubernetes-providers) to do just this! To add the client all you need to do is let the HostBuilder know about it.
+[Steeltoe offers a Kubernetes provider](https://docs.steeltoe.io/api/v3/configuration/kubernetes-providers.html) to do just this! To add the client all you need to do is let the HostBuilder know about it.
 
 ```csharp
 public static IHostBuilder CreateHostBuilder(string[] args) =>     Host.CreateDefaultBuilder(args)
@@ -67,7 +67,7 @@ public WeatherForecastController(IConfiguration config){
 
 Also included is the option to automatically refresh values. When enabled, your application will poll (or maintain an open connection) with the Kubernetes API server. Whenever a value in the ConfigMap is changed, your app’s values will also change -- no restart needed. Whenever a value is added or removed from the ConfigMap (or Secret) your app will automatically see those changes -- also no restart required. That's some cloud-native ninja action!
 
-Getting the value(s) of Kubernetes secrets to the application follows the same pattern as ConfigMaps. Additionally you can pick and choose which source should be made available to the application. [Learn more in the docs](https://steeltoe.io/docs/3/configuration/kubernetes-providers).
+Getting the value(s) of Kubernetes secrets to the application follows the same pattern as ConfigMaps. Additionally you can pick and choose which source should be made available to the application. [Learn more in the docs](https://docs.steeltoe.io/api/v3/configuration/kubernetes-providers.html).
 
 ## If all the services are in the same cluster...
 
@@ -116,7 +116,7 @@ public FortuneService(HttpClient httpClient, ILoggerFactory logFactory){
 }
 ```
 
-[Customizable load-balancing](https://steeltoe.io/docs/3/discovery/load-balancing) between multiple application instances of the same service? Done. Automatic service registration? Done. Steeltoe and Kubernetes are like peanut butter and jelly. They were made for one another.
+[Customizable load-balancing](https://docs.steeltoe.io/api/v3/discovery/load-balancing.html) between multiple application instances of the same service? Done. Automatic service registration? Done. Steeltoe and Kubernetes are like peanut butter and jelly. They were made for one another.
 
 ## Teach Kubernetes what a healthy application is
 
@@ -124,13 +124,13 @@ Any proper platform running containers is going to have a concept of health repo
 
 In Kubernetes, there are two deeper probes offered named `readiness` and `liveness`. Readiness is about ensuring the application is ready to start receiving traffic. While liveness is about making sure the application is still healthy over time.
 
-Fortunately, Steeltoe is here to help set up both of these probes. Using new IHealthContributors and support for grouping, Steeltoe’s [health actuator endpoint](https://steeltoe.io/docs/3/management/health) builds several different views of the app’s dependencies.
+Fortunately, Steeltoe is here to help set up both of these probes. Using new IHealthContributors and support for grouping, Steeltoe’s [health actuator endpoint](https://docs.steeltoe.io/api/v3/management/health.html) builds several different views of the app’s dependencies.
 
 A view is a collection of decisions that reflect the current state of the application. For example if an application depends on a service and it (for some reason) goes offline, then the view should return a negative state. When the service is back up, then the view’s state should update to positive.
 
 The current state of the views are a part of the response body in the health actuator endpoint. Kubernetes uses this to know how the app is doing.
 
-Learn more about Steeltoe’s health endpoint with documentation and code snippets, [here](https://steeltoe.io/docs/3/management/health).
+Learn more about Steeltoe’s health endpoint with documentation and code snippets, [here](https://docs.steeltoe.io/api/v3/management/health.html).
 
 ## Develop locally, as if you’re already in production
 
@@ -150,6 +150,6 @@ Project Tye solves a cloud-native developer’s biggest challenge, environment p
 
 ## Learn more and get started today
 
-To get started with any Steeltoe projects, head over to the [getting started guides](https://steeltoe.io/get-started). Combine this with the samples in the [Steeltoe GitHub repo](https://github.com/SteeltoeOSS/Samples), and you’ll have .NET microservices up and running before you know it!
+To get started with any Steeltoe projects, head over to the [getting started guides](https://docs.steeltoe.io/guides/). Combine this with the samples in the [Steeltoe GitHub repo](https://github.com/SteeltoeOSS/Samples), and you’ll have .NET microservices up and running before you know it!
 
 Want to get deeper into creating cloud-native .NET apps? Attend the VMware Pivotal Labs’s [4 -day .NET developer course](https://pivotal.io/platform-acceleration-lab/pal-for-developers-net). You’ll get hands-on cloud-native .NET training learn best practices when creating microservices and become a Steeltoe ninja!

--- a/guides/application-configuration/cloud-foundry.md
+++ b/guides/application-configuration/cloud-foundry.md
@@ -14,7 +14,7 @@ _hideTocVersionToggle: true
 This tutorial takes you through setting up a .NET Core application that retrieves environment variable values from Cloud Foundry.
 
 > [!NOTE]
-> For more detailed examples, please refer to the [SimpleCloundFoundry](https://github.com/SteeltoeOSS/Samples/tree/main/Configuration/src/SimpleCloudFoundry) project in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
+> For more detailed examples, please refer to the [SimpleCloundFoundry](https://github.com/SteeltoeOSS/Samples/tree/3.x/Configuration/src/SimpleCloudFoundry) project in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
 
 First, **create a .NET Core WebAPI** that retrieves (configuration) environment variables from Cloud Foundry.
 

--- a/guides/application-configuration/placeholder.md
+++ b/guides/application-configuration/placeholder.md
@@ -14,7 +14,7 @@ _hideTocVersionToggle: true
 This tutorial takes you through setting up a .NET Core application that uses placeholders for config values.
 
 > [!NOTE]
-> For more detailed examples, please refer to the [Placeholder](https://github.com/SteeltoeOSS/Samples/tree/main/Configuration/src/Placeholder) project in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
+> For more detailed examples, please refer to the [Placeholder](https://github.com/SteeltoeOSS/Samples/tree/3.x/Configuration/src/Placeholder) project in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
 
 First, **create a .NET Core WebAPI** that has a placeholder implemented
 

--- a/guides/application-configuration/random-value.md
+++ b/guides/application-configuration/random-value.md
@@ -14,7 +14,7 @@ _hideTocVersionToggle: true
 This tutorial takes you through setting up a .NET Core application that gets a random value for a config setting.
 
 > [!NOTE]
-> For more detailed examples, please refer to the [RandomValue](https://github.com/SteeltoeOSS/Samples/tree/main/Configuration/src/RandomValue) project in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
+> For more detailed examples, please refer to the [RandomValue](https://github.com/SteeltoeOSS/Samples/tree/3.x/Configuration/src/RandomValue) project in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
 
 First, **create a .NET Core WebAPI** that has a placeholder implemented.
 

--- a/guides/application-configuration/spring-config.md
+++ b/guides/application-configuration/spring-config.md
@@ -14,7 +14,7 @@ _hideTocVersionToggle: true
 This tutorial takes you through setting up a .NET Core application that gets configuration values from a Spring Config Server.
 
 > [!NOTE]
-> For more detailed examples, please refer to the [Simple (Config Server)](https://github.com/SteeltoeOSS/Samples/tree/main/Configuration/src/Simple) project in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
+> For more detailed examples, please refer to the [Simple (Config Server)](https://github.com/SteeltoeOSS/Samples/tree/3.x/Configuration/src/Simple) project in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
 
 First, **create a GitHub repository** to hold config values.
 

--- a/guides/circuit-breaker/circuit-breaker.md
+++ b/guides/circuit-breaker/circuit-breaker.md
@@ -14,7 +14,7 @@ _hideTocVersionToggle: true
 This tutorial takes you through setting up a .NET Core application that implements a circuit breaker pattern.
 
 > [!NOTE]
-> For more detailed examples, please refer to the [FortuneTeller (Circuit Breaker)](https://github.com/SteeltoeOSS/Samples/tree/main/CircuitBreaker/src/FortuneTeller) project in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
+> For more detailed examples, please refer to the [FortuneTeller (Circuit Breaker)](https://github.com/SteeltoeOSS/Samples/tree/3.x/CircuitBreaker/src/FortuneTeller) project in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
 
 ### Start a instance of the Hystrix dashboard
 

--- a/guides/cloud-management/distributed-tracing.md
+++ b/guides/cloud-management/distributed-tracing.md
@@ -14,7 +14,7 @@ _hideTocVersionToggle: true
 This tutorial takes you through setting up a .NET Core application that sends tracing data to a Zipkin server.
 
 > [!NOTE]
-> For more detailed examples, please refer to the [Tracing](https://github.com/SteeltoeOSS/Samples/tree/main/Management/src/Tracing) project in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
+> For more detailed examples, please refer to the [Tracing](https://github.com/SteeltoeOSS/Samples/tree/3.x/Management/src/Tracing) project in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
 
 First, **start a Zipkin instance**. Depending on your hosting platform this is done in several ways.
 

--- a/guides/cloud-management/endpoints-framework.md
+++ b/guides/cloud-management/endpoints-framework.md
@@ -17,7 +17,7 @@ _hideTocVersionToggle: true
 This tutorial takes you through setting up a ASP.NET 4.x Framework application with cloud management endpoints and dynamic logging levels enabled.
 
 > [!NOTE]
-> For more detailed examples, please refer to the [Management](https://github.com/SteeltoeOSS/Samples/tree/main/Management/src) projects in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
+> For more detailed examples, please refer to the [Management](https://github.com/SteeltoeOSS/Samples/tree/3.x/Management/src) projects in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
 
 **Create a .NET Framework Web API** project
 

--- a/guides/cloud-management/endpoints-netcore.md
+++ b/guides/cloud-management/endpoints-netcore.md
@@ -17,7 +17,7 @@ _hideTocVersionToggle: true
 This tutorial takes you through setting up a .NET Core application with cloud management endpoints automatically added in.
 
 > [!NOTE]
-> For more detailed examples, please refer to the [Management](https://github.com/SteeltoeOSS/Samples/tree/main/Management/src) projects in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
+> For more detailed examples, please refer to the [Management](https://github.com/SteeltoeOSS/Samples/tree/3.x/Management/src) projects in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
 
 **Create a .NET Core WebAPI** with Actuators enabled
 

--- a/guides/messaging/Tutorials/Tutorial1/Readme.md
+++ b/guides/messaging/Tutorials/Tutorial1/Readme.md
@@ -76,7 +76,7 @@ Messaging library to help simplify the code we write while creating our messagin
 
 We have also chosen to use Visual Studio 2022 to edit and build the project; but we could have just as easily chosen VSCode.
 
-The [source code of the tutorials](https://github.com/steeltoeoss/samples/tree/main/messaging/tutorials)
+The [source code of the tutorials](https://github.com/SteeltoeOSS/Samples/tree/3.x/messaging/tutorials)
 is available online. You can either just run the finished tutorials or you can do the tutorials from scratch by following the steps outlined in each of tutorial writeups.
 
 If you choose to start from scratch, open Visual Studio and create a new **Console** application using the VS2022 template:

--- a/guides/observability/grafana.md
+++ b/guides/observability/grafana.md
@@ -14,7 +14,7 @@ _hideTocVersionToggle: true
 This tutorial takes you creating a simple Steeltoe app with actuators, logging, and distributed tracing. With that app running you then export the data to an instance of Prometheus and visualize things in a Grafana dashboard.
 
 > [!NOTE]
-> For more detailed examples, please refer to the [Management](https://github.com/SteeltoeOSS/Samples/tree/main/Management/src) solution in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
+> For more detailed examples, please refer to the [Management](https://github.com/SteeltoeOSS/Samples/tree/3.x/Management/src) solution in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
 
 First, **clone to accompanying repo** that contains all the needed assets
 

--- a/guides/observability/tanzu.md
+++ b/guides/observability/tanzu.md
@@ -14,7 +14,7 @@ _hideTocVersionToggle: true
 This tutorial takes you creating a simple Steeltoe app with actuators, logging, and distributed tracing. With that app running you then export the data to a Tanzu Application Services foundation.
 
 > [!NOTE]
-> For more detailed examples, please refer to the [Management](https://github.com/SteeltoeOSS/Samples/tree/main/Management/src) solution in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
+> For more detailed examples, please refer to the [Management](https://github.com/SteeltoeOSS/Samples/tree/3.x/Management/src) solution in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
 
 ### Prereq's
 

--- a/guides/observability/wavefront.md
+++ b/guides/observability/wavefront.md
@@ -14,7 +14,7 @@ _hideTocVersionToggle: true
 This tutorial takes you creating a simple Steeltoe app with actuators, logging, and distributed tracing. With that app running you then export the data to a Wavefront account.
 
 > [!NOTE]
-> For more detailed examples, please refer to the [Management](https://github.com/SteeltoeOSS/Samples/tree/main/Management/src) solution in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
+> For more detailed examples, please refer to the [Management](https://github.com/SteeltoeOSS/Samples/tree/3.x/Management/src) solution in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
 
 ### Prereq's
 

--- a/guides/security/jwt.md
+++ b/guides/security/jwt.md
@@ -11,4 +11,4 @@ _hideTocVersionToggle: true
 
 ## Using JWT Bearer Tokens
 
-Please refer to our [sample app on GitHub](https://github.com/SteeltoeOSS/Samples/tree/main/Security/src/CloudFoundryJwtAuthentication) for detailed directions on using JWT and Cloud Foundry.
+Please refer to our [sample app on GitHub](https://github.com/SteeltoeOSS/Samples/tree/3.x/Security/src/CloudFoundryJwtAuthentication) for detailed directions on using JWT and Cloud Foundry.

--- a/guides/security/redisstore.md
+++ b/guides/security/redisstore.md
@@ -14,7 +14,7 @@ _hideTocVersionToggle: true
 This tutorial takes you through setting up a .NET Core application that stores its master keys used to protect payloads in an external Redis cache. Learn more about ASP.NET data protection [here](https://docs.microsoft.com/en-us/aspnet/core/security/data-protection).
 
 > [!NOTE]
-> For more detailed examples, please refer to the [RedisDataProtectionKeyStore](https://github.com/SteeltoeOSS/Samples/tree/main/Security/src/RedisDataProtectionKeyStore) project in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
+> For more detailed examples, please refer to the [RedisDataProtectionKeyStore](https://github.com/SteeltoeOSS/Samples/tree/3.x/Security/src/RedisDataProtectionKeyStore) project in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
 
 First, **start a Redis instance**. Using the [Steeltoe dockerfile](https://github.com/steeltoeoss/dockerfiles), start a local instance of RedisStore.
 

--- a/guides/security/sso-oauth.md
+++ b/guides/security/sso-oauth.md
@@ -11,4 +11,4 @@ _hideTocVersionToggle: true
 
 ## Using Cloud Foundry SSO with OAuth2 provider
 
-Please refer to our [sample app on GitHub](https://github.com/SteeltoeOSS/Samples/tree/main/Security/src/CloudFoundrySingleSignon) for detailed directions on using Single Sign-on with OAuth2 and Cloud Foundry.
+Please refer to our [sample app on GitHub](https://github.com/SteeltoeOSS/Samples/tree/3.x/Security/src/CloudFoundrySingleSignon) for detailed directions on using Single Sign-on with OAuth2 and Cloud Foundry.

--- a/guides/security/sso-openid-netcore.md
+++ b/guides/security/sso-openid-netcore.md
@@ -17,7 +17,7 @@ _hideTocVersionToggle: true
 This is a guide to integrate a .Net Core API with the Cloud Foundry SSO identity provider service. The sample provides authentication to select entry points of an application. It is meant to provide authentication simiar to how IIS would when Windows authentication is enabled.
 
 > [!NOTE]
-> For more detailed examples, please refer to the [Security](https://github.com/SteeltoeOSS/Samples/tree/main/Security) section in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
+> For more detailed examples, please refer to the [Security](https://github.com/SteeltoeOSS/Samples/tree/3.x/Security) section in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
 
 First, **establish an identity provider**. Using the [Steeltoe dockerfile](https://github.com/steeltoeoss/dockerfiles), start a local instance of SSO.
 

--- a/guides/service-connectors/mongo.md
+++ b/guides/service-connectors/mongo.md
@@ -14,7 +14,7 @@ _hideTocVersionToggle: true
 This tutorial takes you through setting up a .NET Core application with the Mongo DB service connector.
 
 > [!NOTE]
-> For more detailed examples, please refer to the [MongoDb](https://github.com/SteeltoeOSS/Samples/tree/main/Connectors/src/MongoDb) project in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
+> For more detailed examples, please refer to the [MongoDb](https://github.com/SteeltoeOSS/Samples/tree/3.x/Connectors/src/MongoDb) project in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
 
 First, **start a Mongo DB instance**. Depending on your hosting platform this is done in several ways.
 

--- a/guides/service-connectors/mssql.md
+++ b/guides/service-connectors/mssql.md
@@ -14,7 +14,7 @@ _hideTocVersionToggle: true
 This tutorial takes you through setting up a .NET Core application with the Microsoft SQL service connector.
 
 > [!NOTE]
-> For more detailed examples, please refer to the [SqlServerEFCore](https://github.com/SteeltoeOSS/Samples/tree/main/Connectors/src/SqlServerEFCore) project in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
+> For more detailed examples, please refer to the [SqlServerEFCore](https://github.com/SteeltoeOSS/Samples/tree/3.x/Connectors/src/SqlServerEFCore) project in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
 
 First, **start an MsSQL instance** using the [Steeltoe dockerfile](https://github.com/steeltoeoss/dockerfiles).
 

--- a/guides/service-connectors/mysql.md
+++ b/guides/service-connectors/mysql.md
@@ -14,7 +14,7 @@ _hideTocVersionToggle: true
 This tutorial takes you through setting up a .NET Core application with the MySQL service connector.
 
 > [!NOTE]
-> For more detailed examples, please refer to the [MySql](https://github.com/SteeltoeOSS/Samples/tree/main/Connectors/src/MySql) project in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
+> For more detailed examples, please refer to the [MySql](https://github.com/SteeltoeOSS/Samples/tree/3.x/Connectors/src/MySql) project in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
 
 First, **start a MySQL instance** using the [Steeltoe dockerfile](https://github.com/steeltoeoss/dockerfiles).
 

--- a/guides/service-connectors/oauth.md
+++ b/guides/service-connectors/oauth.md
@@ -11,4 +11,4 @@ _hideTocVersionToggle: true
 
 ## Using Service Connectors with an OAuth2 service
 
-Please refer to our [sample app on GitHub](https://github.com/SteeltoeOSS/Samples/tree/master/Security/src/CloudFoundrySingleSignon)
+Please refer to our [sample app on GitHub](https://github.com/SteeltoeOSS/Samples/tree/3.x/Security/src/CloudFoundrySingleSignon)

--- a/guides/service-connectors/postgresql.md
+++ b/guides/service-connectors/postgresql.md
@@ -14,7 +14,7 @@ _hideTocVersionToggle: true
 This tutorial takes you through setting up a .NET Core application with the PostgreSQL service connector.
 
 > [!NOTE]
-> For more detailed examples, please refer to the [PostgreSql](https://github.com/SteeltoeOSS/Samples/tree/main/Connectors/src/PostgreSql) project in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
+> For more detailed examples, please refer to the [PostgreSql](https://github.com/SteeltoeOSS/Samples/tree/3.x/Connectors/src/PostgreSql) project in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
 
 First, **start a PostgreSQL instance** using the [Steeltoe dockerfile](https://github.com/steeltoeoss/dockerfiles).
 

--- a/guides/service-connectors/rabbitmq.md
+++ b/guides/service-connectors/rabbitmq.md
@@ -14,7 +14,7 @@ _hideTocVersionToggle: true
 This tutorial takes you through setting up a .NET Core application with the RabbitMQ service connector.
 
 > [!NOTE]
-> For more detailed examples, please refer to the [RabbitMQ](https://github.com/SteeltoeOSS/Samples/tree/main/Connectors/src/RabbitMQ) project in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
+> For more detailed examples, please refer to the [RabbitMQ](https://github.com/SteeltoeOSS/Samples/tree/3.x/Connectors/src/RabbitMQ) project in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
 
 First, **start a RabbitMQ instance** using the [Steeltoe dockerfile](https://github.com/steeltoeoss/dockerfiles).
 

--- a/guides/service-connectors/redis.md
+++ b/guides/service-connectors/redis.md
@@ -14,7 +14,7 @@ _hideTocVersionToggle: true
 This tutorial takes you through setting up a .NET Core application with the Redis service connector.
 
 > [!NOTE]
-> For more detailed examples, please refer to the [Redis](https://github.com/SteeltoeOSS/Samples/tree/main/Connectors/src/Redis) project in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
+> For more detailed examples, please refer to the [Redis](https://github.com/SteeltoeOSS/Samples/tree/3.x/Connectors/src/Redis) project in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
 
 First, **start a Redis instance** using the [Steeltoe dockerfile](https://github.com/steeltoeoss/dockerfiles).
 

--- a/guides/service-discovery/eureka.md
+++ b/guides/service-discovery/eureka.md
@@ -14,7 +14,7 @@ _hideTocVersionToggle: true
 This tutorial takes you through setting up two .NET Core applications using services discovery. The first will register it's endpoints for discovery, and the second will discover the first's services.
 
 > [!NOTE]
-> For more detailed examples, please refer to the [FortuneTeller (Discovery)](https://github.com/SteeltoeOSS/Samples/tree/main/Discovery/src) solution in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
+> For more detailed examples, please refer to the [FortuneTeller (Discovery)](https://github.com/SteeltoeOSS/Samples/tree/3.x/Discovery/src) solution in the [Steeltoe Samples Repository](https://github.com/SteeltoeOSS/Samples).
 
 First, **start a Eureka Server** using the [Steeltoe dockerfile](https://github.com/steeltoeoss/dockerfiles), start a local instance of Eureka.
 


### PR DESCRIPTION
- Links to samples for 2.x code now point to https://github.com/SteeltoeOSS/Samples/tree/2.x
- Links to samples for 3.x code now point to https://github.com/SteeltoeOSS/Samples/tree/3.x (new branch even with main)
- dev.steeltoe.io should never have been linked to
