### PR TITLE
Normalize code fences

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Follow the steps below to run/debug locally. The optional steps take longer, but
 
 1. Optional: Build API Browser metadata (clones Steeltoe sources) and process Markdown files in `docs`:
 
-   ```shell
+   ```pwsh
    pwsh .\build\build-metadata.ps1
    ```
 

--- a/build/README.md
+++ b/build/README.md
@@ -6,8 +6,8 @@
 Generate API Browser documentation and process all markdown with the included PowerShell script [build-metadata.ps1](./build-metadata.ps1):
 
 ```pwsh
-cd ./build
-./build-metadata.ps1
+cd build
+pwsh ./build-metadata.ps1
 ```
 
 This process can take a while to complete, will display many warnings and may increase build time in subsequent local runs of Steeltoe.io.

--- a/docs/articles/create-dotnet-microservice-projects-automatically-with-steeltoe-initializr.md
+++ b/docs/articles/create-dotnet-microservice-projects-automatically-with-steeltoe-initializr.md
@@ -48,7 +48,7 @@ We want to create a .NET Core microservice (aka webapi project) that hands us he
 
 # [Powershell](#tab/powershell)
 
-```powershell
+```pwsh
 $body = @{
     Name='MyApp'
     Dependencies='Actuator,Dynamic-Logger,SQLServer'
@@ -60,7 +60,7 @@ Invoke-RestMethod -Uri 'https://start.steeltoe.io/api/project' -Body $body -OutF
 # [Bash](#tab/bash)
 
 ```bash
-$ http https://start.steeltoe.io/api/project dependencies==actuator,dynamic-logger,sqlserver -d
+http https://start.steeltoe.io/api/project dependencies==actuator,dynamic-logger,sqlserver -d
 ```
 
 ***
@@ -105,7 +105,7 @@ Alternatively you could also run the following command:
 
 # [Powershell](#tab/powershell)
 
-```powershell
+```pwsh
 $body = @{
     Name='MyProject'
     Dependencies='Actuator,SQLServer'
@@ -117,7 +117,7 @@ Invoke-RestMethod -Uri 'https://start.steeltoe.io/api/project' -Body $body -OutF
 # [Bash](#tab/bash)
 
 ```bash
-$ http https://start.steeltoe.io/api/project dependencies==actuator,sqlserver -d
+http https://start.steeltoe.io/api/project dependencies==actuator,sqlserver -d
 ```
 
 ***

--- a/docs/articles/steeltoe-3-2-2-adds-kube-service-bindings.md
+++ b/docs/articles/steeltoe-3-2-2-adds-kube-service-bindings.md
@@ -24,16 +24,15 @@ Each of configuration keys is prefixed with `k8s:bindings:<binding-name>` where 
 
 Below is an example of the configuration keys associated with a PostgreSql service binding that are created by the Steeltoe configuration provider.
 
-```csharp
-    k8s:bindings:mypostgres:username=pgappuser
-    k8s:bindings:mypostgres:uri=postgresql://pgappuser:sn3L007KAUC2i598hPtC3ftfgIqvF2@postgres-sample.postgres-service-instances:5432/postgres-sample
-    k8s:bindings:mypostgres:type=postgresql
-    k8s:bindings:mypostgres:provider=vmware
-    k8s:bindings:mypostgres:port=5432
-    k8s:bindings:mypostgres:password=sn3L007KAUC2i598hPtC3ftfgIqvF2
-    k8s:bindings:mypostgres:host=postgres-sample.postgres-service-instances
-    k8s:bindings:mypostgres:database=postgres-sample
-
+```text
+k8s:bindings:mypostgres:username=pgappuser
+k8s:bindings:mypostgres:uri=postgresql://pgappuser:sn3L007KAUC2i598hPtC3ftfgIqvF2@postgres-sample.postgres-service-instances:5432/postgres-sample
+k8s:bindings:mypostgres:type=postgresql
+k8s:bindings:mypostgres:provider=vmware
+k8s:bindings:mypostgres:port=5432
+k8s:bindings:mypostgres:password=sn3L007KAUC2i598hPtC3ftfgIqvF2
+k8s:bindings:mypostgres:host=postgres-sample.postgres-service-instances
+k8s:bindings:mypostgres:database=postgres-sample
 ```
 
 To use the experimental provider, you need to add a reference to the [Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding](https://www.nuget.org/packages/Steeltoe.Extensions.Configuration.Kubernetes.ServiceBinding) NuGet package.
@@ -83,7 +82,6 @@ namespace PostgreSql
         }
     }
 }
-
 ```
 
 Running your application on a Kubernetes platform which supports the [Kubernetes Service Binding](https://github.com/servicebinding/spec) specification you should see configuration key/values appear in your applications configuration.

--- a/docs/docs/v2/configuration/cloud-foundry-provider.md
+++ b/docs/docs/v2/configuration/cloud-foundry-provider.md
@@ -64,7 +64,6 @@ var builder = new ConfigurationBuilder()
     .AddCloudFoundry();
 Configuration = builder.Build();
 ...
-
 ```
 
 When developing a .NET Core application, you can do the same thing by using the `AddCloudFoundry()` extension method for either the `IWebHostBuilder` or Generic `IHostBuilder`. The following example shows how to do so:

--- a/docs/docs/v2/configuration/config-server-provider.md
+++ b/docs/docs/v2/configuration/config-server-provider.md
@@ -245,7 +245,6 @@ The preceding `Configure<MyConfiguration>(Configuration.GetSection("myconfigurat
 After this has been done, you can gain access to the data in your `Controller` or `View` through dependency injection. The following example shows how to do so:
 
 ```csharp
-
 public class HomeController : Controller
 {
     public HomeController(IOptions<MyConfiguration> myOptions)

--- a/docs/docs/v2/configuration/placeholder-provider.md
+++ b/docs/docs/v2/configuration/placeholder-provider.md
@@ -70,7 +70,6 @@ var builder = new ConfigurationBuilder()
     .AddPlaceholderResolver();
 Configuration = builder.Build();
 ...
-
 ```
 
 Extensions are also provided for quick addition to both `IHostBuilder` and `IWebHostBuilder`. Their usage is identical - the following example shows how to add to the `IWebHostBuilder`:
@@ -183,7 +182,6 @@ public class Program
 Then to use the configuration and the added Placeholder resolver together with your Options classes simply configure the Options as you normally would.
 
 ```csharp
-
 // Options class
 public class SampleOptions
 {

--- a/docs/docs/v2/configuration/random-value-provider.md
+++ b/docs/docs/v2/configuration/random-value-provider.md
@@ -11,7 +11,6 @@ var my_big_number = config["random:long"];
 var my_uuid = config["random:uuid"];
 var my_number_less_than_ten = config["random:int(10)"];
 var my_number_in_range = config["random:int[1024,65536]"];
-
 ```
 
 You can also use the generator together with property placeholders. For example, consider the following `appsettings.json`
@@ -82,7 +81,6 @@ var builder = new ConfigurationBuilder()
     .AddRandomValueSource();
 Configuration = builder.Build();
 ...
-
 ```
 
 >NOTE: It if you wish to generate random values as part of using placeholders, then it's important to add the RandomValue provider to the builder before you add the Placeholder resolver.

--- a/docs/docs/v2/connectors/gemfire.md
+++ b/docs/docs/v2/connectors/gemfire.md
@@ -85,8 +85,8 @@ If your application fails to [programmatically create regions](https://gemfire-n
 
 Use gfsh to connect to the cluster and create the region:
 
-```bash
-gfsh>connect --url=https://cloudcache-someguid.run.pcfone.io/gemfire/v1 --user=cluster_operator_****** --password=******
+```text
+gfsh> connect --url=https://cloudcache-someguid.run.pcfone.io/gemfire/v1 --user=cluster_operator_****** --password=******
 
 Successfully connected to: GemFire Manager HTTP service @ https://cloudcache-someguid.run.pcfone.io/gemfire/v1
 

--- a/docs/docs/v2/connectors/microsoft-sql-server.md
+++ b/docs/docs/v2/connectors/microsoft-sql-server.md
@@ -237,7 +237,6 @@ public class TestContext : DbContext
     }
     public DbSet<TestData> TestData { get; set; }
 }
-
 ```
 
 If you need to set additional properties for the `DbContext` like `MigrationsAssembly` or connection retry settings, create an `Action<SqlServerDbContextOptionsBuilder>` like this:

--- a/docs/docs/v2/connectors/microsoft-sql-server.md
+++ b/docs/docs/v2/connectors/microsoft-sql-server.md
@@ -62,13 +62,13 @@ The samples and most templates are already set up to read from `appsettings.json
 
 To use Microsoft SQL Server on Cloud Foundry, you need a service instance bound to your application. If the [Microsoft SQL Server broker](https://github.com/cf-platform-eng/mssql-server-broker) is installed in your Cloud Foundry instance, use it to create a new service instance, as follows:
 
-```bash
+```shell
 cf create-service SqlServer sharedVM mySqlServerService
 ```
 
 An alternative to the broker is to use a user-provided service to explicitly provide connection information to the application, as shown in the following example:
 
-```bash
+```shell
 cf cups mySqlServerService -p '{"pw": "|password|","uid": "|user id|","uri": "jdbc:sqlserver://|host|:|port|;databaseName=|database name|"}'
 ```
 

--- a/docs/docs/v2/connectors/mysql.md
+++ b/docs/docs/v2/connectors/mysql.md
@@ -254,7 +254,6 @@ public class TestContext : DbContext
     }
     public DbSet<TestData> TestData { get; set; }
 }
-
 ```
 
 If you need to set additional properties for the `DbContext` like `MigrationsAssembly` or connection retry settings, create an `Action<MySqlDbContextOptionsBuilder>` like this:

--- a/docs/docs/v2/connectors/postgresql.md
+++ b/docs/docs/v2/connectors/postgresql.md
@@ -140,7 +140,6 @@ public class HomeController : Controller
         return View();
     }
 }
-
 ```
 
 ### Add DbContext

--- a/docs/docs/v2/connectors/rabbitmq.md
+++ b/docs/docs/v2/connectors/rabbitmq.md
@@ -132,5 +132,4 @@ using RabbitMQ.Client;
      }
 
  }
-
  ```

--- a/docs/docs/v2/developer-tools/cli.md
+++ b/docs/docs/v2/developer-tools/cli.md
@@ -11,28 +11,30 @@ There are 3 basic steps when using Steeltoe Tooling:
 
 ### Install Steeltoe Tooling
 
-Steeltoe Tooling is a [DotNet Global Tools](https://docs.microsoft.com/dotnet/core/tools/global-tools) console executable named `st`.  Use `dotnet tool install` to install.
+Steeltoe Tooling is a [DotNet Global Tool](https://docs.microsoft.com/dotnet/core/tools/global-tools) console executable named `st`.  Use `dotnet tool install` to install.
 
-```sh
-$ dotnet tool install --global --version 0.5.0 Steeltoe.Cli
+```shell
+dotnet tool install --global --version 0.5.0 Steeltoe.Cli
 ```
 
-### Add DotNet Global Tools to your PATH Variable
+### Add the DotNet Global Tool to your PATH variable
 
-DotNet Global Tools are installed in an OS-dependent user directory.
+The DotNet Global Tool is installed in an OS-dependent user directory.
 
 |OS|Path|
 |---|---|
 |Windows|`%USERPROFILE%\.dotnet\tools`|
 |OS X/Linux|`$HOME/.dotnet/tools`|
 
-After adding of the above paths to your `PATH` env var, you can run the `st` executable.
+After adding the above paths to your `PATH` env var, you can run the `st` executable.
 
-```sh
-$ st --version
-1.0.0-m1
+```shell
+st --version
 ```
 
+```text
+1.0.0-m1
+```
 
 ## Usage of Tooling CLI
 
@@ -40,9 +42,12 @@ $ st --version
 
 The `st init` command initializes your project for Steeltoo Tooling.  Enter your project directory and run the command.
 
-```sh
-$ cd MyProject
-$ st init
+```shell
+cd MyProject
+st init
+```
+
+```text
 Initialized Steeltoe Developer Tools
 ```
 
@@ -56,8 +61,11 @@ The `st add-app`, `st add-service`, and `st remove` commands add and remove appl
 
 Running `st add-app <appname>` adds an application to the configuration. _appname_ must correspond to a `.csproj` file of the same name.
 
-```sh
-$ st add-app MyProject
+```shell
+st add-app MyProject
+```
+
+```text
 Added app 'MyProject'
 ```
 
@@ -79,8 +87,11 @@ Supported service types include:
 |redis|Redis In-Memory Datastore|
 |zipkin|Zipkin Tracing Collector and UI|
 
-```sh
-$ st add-service config-server MyConfigServer
+```shell
+st add-service config-server MyConfigServer
+```
+
+```text
 Added config-server service 'MyConfigServer'
 ```
 
@@ -88,8 +99,11 @@ Added config-server service 'MyConfigServer'
 
 Running `st remove <name>` removes the named application or service.
 
-```sh
-$ st remove myConfigServer
+```shell
+st remove myConfigServer
+```
+
+```text
 Removed config-server service 'myConfigServer'
 ```
 
@@ -107,8 +121,11 @@ Supported targets include:
 |docker|local Docker host|
 |kubernetes|current Kubernetes context|
 
-```sh
-$ st target kubernetes
+```shell
+st target kubernetes
+```
+
+```text
 Kubernetes ... kubectl client version 1.14, server version 1.14
 current context ... docker-desktop
 Target set to 'kubernetes'
@@ -118,8 +135,11 @@ Target set to 'kubernetes'
 
 Running `st deploy` deploys an application and its services to the current target.
 
-```sh
-$ st deploy
+```shell
+st deploy
+```
+
+```text
 Deploying service 'myConfigServer'
 Waiting for service 'myConfigServer' to come online (1)
 Waiting for service 'myConfigServer' to come online (2)
@@ -130,8 +150,11 @@ Deploying app 'SimpleCloudFoundry'
 
 Running `st undeploy` undeploys an application and its services from the current target.
 
-```sh
-$ st undeploy
+```shell
+st undeploy
+```
+
+```text
 Undeploying app 'SimpleCloudFoundry'
 Undeploying service 'myConfigServer'
 ```
@@ -144,29 +167,40 @@ In this sample we use Steeltoe Tooling to simplify the process of deploying the 
 
 Checkout Steeltoe Samples and navigate to the Redis Connector sample.
 
-```sh
-$ git clone https://github.com/SteeltoeOSS/Samples.git
-$ cd Samples/Connectors/src/AspDotNetCore/Redis
+```shell
+git clone https://github.com/SteeltoeOSS/Samples.git
+cd Samples/Connectors/src/AspDotNetCore/Redis
 ```
 
 Initialize Steeltoe Tooling.
 
-```sh
-$ st init
+```shell
+st init
+```
+
+```text
 Initialized Steeltoe Developer Tools
 ```
 
 ### Add the Application and Service
 
 Add application.
-```sh
-$ st add-app Redis
+
+```shell
+st add-app Redis
+```
+
+```text
 Added app 'Redis' (netcoreapp3.1/win10-x64)
 ```
 
 Add service.
-```sh
-$ st add-service redis myRedisService
+
+```shell
+st add-service redis myRedisService
+```
+
+```text
 Added redis service 'myRedisService'
 ```
 
@@ -176,8 +210,11 @@ Added redis service 'myRedisService'
 
 Before deploying to a remote cloud, first run locally using Docker ...
 
-```sh
-$ st target docker
+```shell
+st target docker
+```
+
+```text
 Docker ... Docker version 18.09.1, build 4c52b90
 Docker host OS ... Docker for Mac
 Docker container OS ... linux
@@ -186,8 +223,8 @@ Target set to 'docker'
 
 ... create a DotNet Configuration file named `appsettings.Docker.json` ...
 
-```sh
-$ cat appsettings.Docker.json
+```bash
+cat appsettings.Docker.json
 {
   "redis": {
     "client": {
@@ -201,15 +238,21 @@ $ cat appsettings.Docker.json
 ... deploy to Docker ...
 
 ```bash
-$ st deploy
+st deploy
+```
+
+```text
 Deploying service 'myRedisService'
 Deploying app 'Redis'
 ```
 
 ... check status ...
 
-```sh
-$ st status
+```shell
+st status
+```
+
+```text
 myRedisService online
 Redis online
 ```
@@ -220,8 +263,11 @@ Redis online
 
 ... finally, undeploy.
 
-```sh
-$ st undeploy
+```shell
+st undeploy
+```
+
+```text
 Undeploying app 'Redis'
 Undeploying service 'myRedisService'
 ```
@@ -230,29 +276,43 @@ Undeploying service 'myRedisService'
 
 Deploy to Cloud Foundry ...
 
-```sh
-$ st target cloud-foundry
+```shell
+st target cloud-foundry
+```
+
+```text
 Cloud Foundry ... cf version 6.46.0+29d6257f1.2019-07-09
 logged into Cloud Foundry ... yes
 Target set to 'cloud-foundry'
+```
 
-$ st deploy
+```shell
+st deploy
+```
+
+```text
 Deploying service 'myRedisService'
 Deploying app 'Redis'
 ```
 
 ... check status ...
 
-```sh
-$ st status
+```shell
+st status
+```
+
+```text
 myRedisService online
 Redis online
 ```
 
 ... and undeploy.
 
-```sh
-$ st undeploy
+```shell
+st undeploy
+```
+
+```text
 Undeploying app 'Redis'
 Undeploying service 'myRedisService'
 ```
@@ -263,15 +323,25 @@ If you haven't already, create a DotNet Configuration file named `appsettings.Do
 
 ... deploy to Kubernetes ...
 
-```sh
-$ eval $(minikube docker-env)  # if using minikube's Docker
+```bash
+eval $(minikube docker-env)  # if using minikube's Docker
+```
 
-$ st target kubernetes
+```shell
+st target kubernetes
+```
+
+```text
 Kubernetes ... kubectl client version 1.15, server version 1.15
 current context ... minikube
 Target set to 'kubernetes'
+```
 
-$ st deploy
+```shell
+st deploy
+```
+
+```text
 Deploying service 'myRedisService'
 Waiting for 'myRedisService' to transition to online (1)
 Waiting for 'myRedisService' to transition to online (2)
@@ -285,22 +355,35 @@ Waiting for 'Redis' to transition to online (4)
 
 ... check status ...
 
-```sh
-$ st status
+```shell
+st status
+```
+
+```text
 myRedisService online
 Redis online
 ```
 
 ... enable port-forwarding to the app running in Kubernetes ...
 
-```sh
-# determine pod name
-$ kubectl get pods --selector app=redis
+Determine pod name:
+
+```shell
+kubectl get pods --selector app=redis
+```
+
+```text
 NAME                     READY   STATUS    RESTARTS   AGE
 redis-57fc6b5c85-9n4z9   1/1     Running   0          87s
+```
 
-# forward port 8080 to pod
-$ kubectl port-forward redis-57fc6b5c85-9n4z9 8080:80
+Forward port 8080 to pod:
+
+```shell
+kubectl port-forward redis-57fc6b5c85-9n4z9 8080:80
+```
+
+```text
 Forwarding from 127.0.0.1:8080 -> 80
 Forwarding from [::1]:8080 -> 80
 ...
@@ -312,8 +395,11 @@ Forwarding from [::1]:8080 -> 80
 
 ... and undeploy.
 
-```sh
-$ st undeploy
+```shell
+st undeploy
+```
+
+```text
 Undeploying app 'Redis'
 Undeploying service 'myRedisService'
 ```

--- a/docs/docs/v2/developer-tools/cli.md
+++ b/docs/docs/v2/developer-tools/cli.md
@@ -200,7 +200,7 @@ $ cat appsettings.Docker.json
 
 ... deploy to Docker ...
 
-```
+```bash
 $ st deploy
 Deploying service 'myRedisService'
 Deploying app 'Redis'

--- a/docs/docs/v2/management/metrics.md
+++ b/docs/docs/v2/management/metrics.md
@@ -73,10 +73,10 @@ To add this type of NuGet to your project, add a `PackageReference` resembling t
 </ItemGroup>
 ```
 
-or
+Or, from the command line:
 
-```powershell
-PM>Install-Package  Steeltoe.Management.ExporterCore -Version 2.5.2
+```shell
+dotnet add package Steeltoe.Management.ExporterCore --version 2.5.2
 ```
 
 ## Cloud Foundry Forwarder

--- a/docs/docs/v2/management/prometheus.md
+++ b/docs/docs/v2/management/prometheus.md
@@ -76,6 +76,6 @@ scrape_configs:
 ```
 Running Prometheus server with this configuration will allow you view metrics in the built-in UI. Other visualization tools such as [Grafana](https://grafana.com/docs/grafana/latest/features/datasources/prometheus/) can then be configured to use Prometheus as a datasource.
 
-```docker
+```shell
 docker run -d  --name=prometheus -p 9090:9090 -v <Absolute-Path>/prometheus.yml:/etc/prometheus/prometheus.yml prom/prometheus --config.file=/etc/prometheus/prometheus.yml
 ```

--- a/docs/docs/v2/management/prometheus.md
+++ b/docs/docs/v2/management/prometheus.md
@@ -41,10 +41,10 @@ To use the prometheus endpoint, you need to add a reference to `Steetoe.Manageme
 </ItemGroup>
 ```
 
-or
+Or, from the command line:
 
-```powershell
-PM>Install-Package  Steeltoe.Management.EndpointCore -Version 2.5.2
+```shell
+dotnet add package Steeltoe.Management.EndpointCore --version 2.5.2
 ```
 
 ## Cloud Foundry Forwarder

--- a/docs/docs/v2/management/prometheus.md
+++ b/docs/docs/v2/management/prometheus.md
@@ -61,7 +61,7 @@ To register your endpoint for metrics collection install the metrics-registrar p
 
 [Prometheus Server](https://prometheus.io/) can be set up to scrape this endpoint by registering your application in the server's configuration. For example, this prometheus.yml expects a Steeltoe-enabled app running on port 8000 with the actuator management path at the default of /actuator:
 
-```yml
+```yaml
 global:
   scrape_interval: 15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
   evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.

--- a/docs/docs/v2/management/tasks.md
+++ b/docs/docs/v2/management/tasks.md
@@ -18,10 +18,10 @@ Add the following PackageReference to your .csproj file.
 </ItemGroup>
 ```
 
-or
+Or, from the command line:
 
-```powershell
-PM>Install-Package  Steeltoe.Management.TaskCore -Version 2.5.2
+```shell
+dotnet add package Steeltoe.Management.TaskCore --version 2.5.2
 ```
 
 ## Implement Task

--- a/docs/docs/v2/management/using-endpoints.md
+++ b/docs/docs/v2/management/using-endpoints.md
@@ -62,10 +62,10 @@ To add this type of NuGet to your project, add a `PackageReference` resembling t
 </ItemGroup>
 ```
 
-or
+Or, from the command line:
 
-```powershell
-PM>Install-Package  Steeltoe.Management.EndpointWeb -Version 2.5.2
+```shell
+dotnet add package Steeltoe.Management.EndpointCore --version 2.5.2
 ```
 
 ## Configure Global Settings

--- a/docs/docs/v2/tracing/distributed-tracing-exporting.md
+++ b/docs/docs/v2/tracing/distributed-tracing-exporting.md
@@ -22,10 +22,10 @@ To use an exporter in a ASP.NET Core application, then add the following `Packag
 </ItemGroup>
 ```
 
-or
+Or, from the command line:
 
-```powershell
-PM>Install-Package  Steeltoe.Management.ExporterCore -Version 2.5.2
+```shell
+dotnet add package Steeltoe.Management.ExporterCore --version 2.5.2
 ```
 
 ### Zipkin Server

--- a/docs/docs/v2/tracing/index.md
+++ b/docs/docs/v2/tracing/index.md
@@ -48,15 +48,15 @@ To add this type of NuGet to your project, add a `PackageReference` resembling t
 ```xml
 <ItemGroup>
 ...
-    <PackageReference Include="Steeltoe.Management.TracingCore" Version="2.5.4" />
+    <PackageReference Include="Steeltoe.Management.TracingCore" Version="2.5.2" />
 ...
 </ItemGroup>
 ```
 
-or
+Or, from the command line:
 
-```powershell
-PM>Install-Package  Steeltoe.Management.TracingCore -Version 2.5.2
+```shell
+dotnet add package Steeltoe.Management.TracingCore --version 2.5.2
 ```
 
 ### Configure Settings

--- a/docs/docs/v2/welcome/common-steps.md
+++ b/docs/docs/v2/welcome/common-steps.md
@@ -22,16 +22,23 @@ Use the `dotnet` CLI to [build and locally publish](https://docs.microsoft.com/d
 
 Use the Cloud Foundry CLI to push the published application to Cloud Foundry using the parameters that match what you selected for framework and runtime:
 
-```bash
-# Push to Linux cell
-cf push -f manifest.yml -p bin/Debug/netcoreapp3.1/linux-x64/publish
+- Push to Linux cell:
 
-# Push to Windows cell, .NET Core
-cf push -f manifest-windows.yml -p bin/Debug/netcoreapp3.1/win10-x64/publish
+  ```shell
+  cf push -f manifest.yml -p bin/Debug/netcoreapp3.1/linux-x64/publish
+  ```
 
-# Push to Windows cell, .NET Framework
-cf push -f manifest-windows.yml -p bin/Debug/net461/win10-x64/publish
-```
+- Push to Windows cell, .NET Core:
+
+  ```shell
+  cf push -f manifest-windows.yml -p bin/Debug/netcoreapp3.1/win10-x64/publish
+  ```
+
+- Push to Windows cell, .NET Framework:
+
+  ```shell
+  cf push -f manifest-windows.yml -p bin/Debug/net461/win10-x64/publish
+  ```
 
 >NOTE: all sample manifests have been defined to bind their application to their service(s) as created above.
 
@@ -41,7 +48,7 @@ To see the logs as you startup the application, use `cf logs oauth`.
 
 On a Linux cell, you should see something resembling the following during startup:
 
-```bash
+```text
 2016-06-01T09:14:14.38-0600 [CELL/0]     OUT Creating container
 2016-06-01T09:14:15.93-0600 [CELL/0]     OUT Successfully created container
 2016-06-01T09:14:17.14-0600 [CELL/0]     OUT Starting health monitoring of container

--- a/docs/docs/v3/bootstrap/index.md
+++ b/docs/docs/v3/bootstrap/index.md
@@ -35,7 +35,6 @@ namespace WebApplication1
                 .AddSteeltoe();
     }
 }
-
 ```
 
 ## Supported Steeltoe Packages

--- a/docs/docs/v3/circuitbreaker/hystrix.md
+++ b/docs/docs/v3/circuitbreaker/hystrix.md
@@ -857,7 +857,7 @@ Once you have made the changes described earlier, you can then use the Netflix H
 
 There are a few images available on Docker Hub that provide basic Hystrix Dashboard functionality. This example has been tested with:
 
-```bash
+```shell
 docker run --rm -ti -p 7979:7979 --name steeltoe-hystrix steeltoeoss/hystrix-dashboard
 ```
 

--- a/docs/docs/v3/configuration/cloud-foundry-provider.md
+++ b/docs/docs/v3/configuration/cloud-foundry-provider.md
@@ -55,7 +55,6 @@ var builder = new ConfigurationBuilder()
     .AddCloudFoundry();
 Configuration = builder.Build();
 ...
-
 ```
 
 When developing a .NET Core application, you can do the same thing by using the `AddCloudFoundryConfiguration()` extension method for either the `IWebHostBuilder` or Generic `IHostBuilder`. The following example shows how to do so:

--- a/docs/docs/v3/configuration/config-server-provider.md
+++ b/docs/docs/v3/configuration/config-server-provider.md
@@ -236,7 +236,6 @@ The preceding `Configure<MyConfiguration>(Configuration.GetSection("myconfigurat
 After this has been done, you can gain access to the data in your `Controller` or `View` through dependency injection. The following example shows how to do so:
 
 ```csharp
-
 public class HomeController : Controller
 {
     public HomeController(IOptions<MyConfiguration> myOptions)

--- a/docs/docs/v3/configuration/placeholder-provider.md
+++ b/docs/docs/v3/configuration/placeholder-provider.md
@@ -62,7 +62,6 @@ var builder = new ConfigurationBuilder()
     .AddPlaceholderResolver();
 Configuration = builder.Build();
 ...
-
 ```
 
 Extensions are also provided for quick addition to both `IHostBuilder` and `IWebHostBuilder`. Their usage is identical. The following example shows how to add to the `IWebHostBuilder`:
@@ -175,7 +174,6 @@ public class Program
 Then, to use the configuration and the added placeholder resolver together with your Options classes, you can configure the Options as you normally would:
 
 ```csharp
-
 // Options class
 public class SampleOptions
 {

--- a/docs/docs/v3/configuration/random-value-provider.md
+++ b/docs/docs/v3/configuration/random-value-provider.md
@@ -11,7 +11,6 @@ var my_big_number = config["random:long"];
 var my_uuid = config["random:uuid"];
 var my_number_less_than_ten = config["random:int(10)"];
 var my_number_in_range = config["random:int[1024,65536]"];
-
 ```
 
 You can also use the generator together with property placeholders. For example, consider the following `appsettings.json`:
@@ -72,7 +71,6 @@ var builder = new ConfigurationBuilder()
     .AddRandomValueSource();
 Configuration = builder.Build();
 ...
-
 ```
 
 >If you wish to generate random values as part of using placeholders, you need to add the `RandomValue` provider to the builder before you add the placeholder resolver.

--- a/docs/docs/v3/connectors/microsoft-sql-server.md
+++ b/docs/docs/v3/connectors/microsoft-sql-server.md
@@ -244,7 +244,6 @@ public class TestContext : DbContext
     }
     public DbSet<TestData> TestData { get; set; }
 }
-
 ```
 
 If you need to set additional properties for the `DbContext` (such as `MigrationsAssembly` or connection retry settings), create an `Action<SqlServerDbContextOptionsBuilder>`:

--- a/docs/docs/v3/connectors/microsoft-sql-server.md
+++ b/docs/docs/v3/connectors/microsoft-sql-server.md
@@ -67,13 +67,13 @@ The samples and most templates are already set up to read from `appsettings.json
 
 To use Microsoft SQL Server on Cloud Foundry, you need a service instance bound to your application. If the [Microsoft SQL Server broker](https://github.com/cf-platform-eng/mssql-server-broker) is installed in your Cloud Foundry instance, use it to create a new service instance:
 
-```bash
+```shell
 cf create-service SqlServer sharedVM mySqlServerService
 ```
 
 An alternative to the broker is to use a user-provided service to explicitly provide connection information to the application:
 
-```bash
+```shell
 cf cups mySqlServerService -p '{"pw": "|password|","uid": "|user id|","uri": "jdbc:sqlserver://|host|:|port|;databaseName=|database name|"}'
 ```
 

--- a/docs/docs/v3/developer-tools/cli.md
+++ b/docs/docs/v3/developer-tools/cli.md
@@ -24,7 +24,7 @@ See [docker-compose](https://docs.docker.com/compose/)
 
 Steeltoe Tooling is a [DotNet Global Tools](https://docs.microsoft.com/dotnet/core/tools/global-tools) console executable named `st`.  Use `dotnet tool install` to install.
 
-```sh
+```shell
 dotnet tool install -g Steeltoe.Cli --version 0.7.1-2785 --add-source https://www.myget.org/F/steeltoedev/api/v3/index.json
 ```
 
@@ -39,8 +39,11 @@ DotNet Global Tools are installed in an OS-dependent user directory
 
 After adding of the path to your `PATH` environment variable, you can run the `st` executable:
 
-```sh
-$ st --version
+```shell
+st --version
+```
+
+```text
 0.7.1 (build 2785 -> https://dev.azure.com/SteeltoeOSS/Steeltoe/_build/results?buildId=2785)
 ```
 
@@ -50,21 +53,21 @@ You can create the sample application used by using the [Steeltoe Initializr](ht
 
 To create it in your environment:
 
-```sh
-$ mkdir MyRedisApp
-$ curl https://start.steeltoe.io/starter.zip -o MyRedisApp.zip \
-    -dprojectName=MyRedisApp \
-    -dtargetFrameworkVersion=netcoreapp3.1 \
-    -ddependencies=redis
-$ unzip MyRedisApp.zip -d MyRedisApp
-$ cd MyRedisApp
+```bash
+mkdir MyRedisApp
+curl https://start.steeltoe.io/starter.zip -o MyRedisApp.zip \
+  -dprojectName=MyRedisApp \
+  -dtargetFrameworkVersion=netcoreapp3.1 \
+  -ddependencies=redis
+unzip MyRedisApp.zip -d MyRedisApp
+cd MyRedisApp
 ```
 
 ### Using show
 
 The following example shows how to use the `show` command:
 
-```sh
+```text
 Displays project details
 
 Usage: st show [options]
@@ -86,8 +89,11 @@ This structure is subsequently used by the `run` command to start the project an
 Running `show` in our example application shows that the project application is a `netcoreapp3.1` application that listens on port `5000` for HTTP requests.
 The application depends on Redis to be listening on port `5672`.
 
-```sh
-$ st show
+```shell
+st show
+```
+
+```text
 configuration: MyRedisApp
 project:
   name: myredisapp
@@ -107,7 +113,7 @@ project:
 
 The following example shows how to use the `run` command:
 
-```sh
+```text
 Runs project in the local Docker environment
 
 Usage: st run [options]
@@ -138,8 +144,11 @@ If the project has service dependencies, Docker containers are created for each 
 
 Running `run` in our example app starts up the application and its dependent Redis service:
 
-```sh
-$ st run
+```shell
+st run
+```
+
+```text
 running 'myredisapp' in Docker
 > docker-compose up --build
 Creating network "myredisapp_default" with the default driver
@@ -189,7 +198,7 @@ myredisapp_1  | Application started. Press Ctrl+C to shut down.
 
 The following example shows how to use the `stop` command:
 
-```sh
+```text
 Stops project running in the local Docker environment
 
 Usage: st stop [options]
@@ -212,8 +221,11 @@ Running `stop` stops the project running in your local Docker environment.
 
 Running `stop` in our example application tears down the project's Docker containers:
 
-```sh
-$ st stop
+```shell
+st stop
+```
+
+```text
 stopping 'myredisapp' in Docker
 > docker-compose down
 Stopping myredisapp_redis_1      ...

--- a/docs/docs/v3/management/metrics-endpoint.md
+++ b/docs/docs/v3/management/metrics-endpoint.md
@@ -54,10 +54,10 @@ To add this type of NuGet to your project, add a `PackageReference` resembling t
 </ItemGroup>
 ```
 
-Alternatively, you can add the package through PowerShell:
+Or, from the command line:
 
-```powershell
-PM>Install-Package  Steeltoe.Management.EndpointCore
+```shell
+dotnet add package Steeltoe.Management.EndpointCore --version 3.2.0
 ```
 
 ## ASP NET Core Example

--- a/docs/docs/v3/management/metrics.md
+++ b/docs/docs/v3/management/metrics.md
@@ -16,10 +16,10 @@ To add this type of NuGet to your project, add a `PackageReference` resembling t
 </ItemGroup>
 ```
 
-Alternatively, you can add the package through PowerShell:
+Or, from the command line:
 
-```powershell
-PM>Install-Package  Steeltoe.Management.EndpointCore -Version 3.2.0
+```shell
+dotnet add package Steeltoe.Management.EndpointCore --version 3.2.0
 ```
 
 ## Metric Observers
@@ -107,7 +107,7 @@ To emit custom metrics on TAS for VMs v2.5 or later, use the Metric Registrar. F
 
 To register your endpoint for metrics collection, install the metrics-registrar plugin and use it to register your endpoint:
 
-```bash
+```shell
 cf install-plugin -r CF-Community "metric-registrar"`
 cf register-metrics-endpoint your-dotnet-app /actuator/prometheus
 ```
@@ -132,7 +132,7 @@ scrape_configs:
 
 Running Prometheus server with this configuration lets you view metrics in the built-in UI. You can then configure other visualization tools, such as [Grafana](https://grafana.com/docs/grafana/latest/features/datasources/prometheus/), to use Prometheus as a datasource. The following example shows how to run Prometheus in Docker:
 
-```bash
+```shell
 docker run -d  --name=prometheus -p 9090:9090 -v <Absolute-Path>/prometheus.yml:/etc/prometheus/prometheus.yml prom/prometheus --config.file=/etc/prometheus/prometheus.yml
 ```
 

--- a/docs/docs/v3/management/metrics.md
+++ b/docs/docs/v3/management/metrics.md
@@ -116,7 +116,7 @@ cf register-metrics-endpoint your-dotnet-app /actuator/prometheus
 
 You can set up [Prometheus Server](https://prometheus.io/) to scrape this endpoint by registering your application in the server's configuration. For example, the following `prometheus.yml` file expects a Steeltoe-enabled application to be running on port 8000 with the actuator management path at the default of `/actuator`:
 
-```yml
+```yaml
 global:
   scrape_interval: 15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
   evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.

--- a/docs/docs/v3/management/prometheus.md
+++ b/docs/docs/v3/management/prometheus.md
@@ -50,8 +50,8 @@ To use the Prometheus endpoint, you need to add a reference to `Steeltoe.Managem
 </ItemGroup>
 ```
 
-Alternatively, you can use PowerShell:
+Or, from the command line:
 
-```powershell
-PM>Install-Package  Steeltoe.Management.EndpointCore
+```shell
+dotnet add package Steeltoe.Management.EndpointCore --version 3.2.0
 ```

--- a/docs/docs/v3/management/springbootadmin.md
+++ b/docs/docs/v3/management/springbootadmin.md
@@ -66,6 +66,6 @@ Here is an example settings file.
 
 For testing, you can use a version of spring boot admin server running locally.
 
-```bash
+```shell
 docker run -d -p 8080:8080 steeltoeoss/spring-boot-admin
 ```

--- a/docs/docs/v3/management/tasks.md
+++ b/docs/docs/v3/management/tasks.md
@@ -16,10 +16,10 @@ Add the following PackageReference to your .csproj file.
 </ItemGroup>
 ```
 
-Alternatively, you can use PowerShell:
+Or, from the command line:
 
-```powershell
-PM>Install-Package  Steeltoe.Management.TaskCore
+```shell
+dotnet add package Steeltoe.Management.TaskCore --version 3.2.0
 ```
 
 ## Implement Task Interface

--- a/docs/docs/v3/messaging/rabbitmq-intro.md
+++ b/docs/docs/v3/messaging/rabbitmq-intro.md
@@ -399,7 +399,6 @@ public void ConfigureServices(IServiceCollection services)
 When using the WebApplication Builder, or if you prefer not to use the RabbitMQHost within your application, you will need to add the below additional configuration to the service container to get Steelotoe RabbitMQ services up and running:
 
 ```csharp
-
     var builder = WebApplication.CreateBuilder(args);
 
     // Configure the RabbitMQ client connection;

--- a/docs/docs/v3/messaging/rabbitmq-intro.md
+++ b/docs/docs/v3/messaging/rabbitmq-intro.md
@@ -10,7 +10,7 @@ Prerequisites: [Download RabbitMQ broker](https://www.rabbitmq.com/download.html
 Then grab the `Steeltoe.Messaging.RabbitMQ` nuget and all its dependencies. The easiest way to do so is to declare a dependency in your build tool.
 For example, simply add the following to your `.csproj` file:
 
-```XML
+```xml
   <ItemGroup>
     <PackageReference Include="Steeltoe.Messaging.RabbitMQ" Version="3.x.x" />
   </ItemGroup>

--- a/docs/docs/v3/messaging/rabbitmq-reference.md
+++ b/docs/docs/v3/messaging/rabbitmq-reference.md
@@ -1774,7 +1774,7 @@ runtime SpEL expression (described after the next example).
 The `@SendTo` can be a SpEL expression that is evaluated at runtime against the request
 and reply, as the following example shows:
 
-```Java
+```java
 @RabbitListener(queues = "test.sendTo.spel")
 @SendTo("!{'some.reply.queue.with.' + result.queueName}")
 public Bar capitalizeWithSendToSpel(Foo foo) {
@@ -1800,7 +1800,7 @@ Beans are referenced with their names, prefixed by `@`.
 Simple property placeholders are also supported (for example, `${some.reply.to}`).
 With earlier versions, the following can be used as a work around, as the following example shows:
 
-```Java
+```java
 @RabbitListener(queues = "foo")
 @SendTo("#{environment['my.send.to']}")
 public String listen(Message in) {
@@ -2851,7 +2851,7 @@ Events are published by the broker to a topic exchange `amq.rabbitmq.event` with
 The listener uses event keys, which are used to bind an `AnonymousQueue` to the exchange so the listener receives only selected events.
 Since it is a topic exchange, wildcards can be used (as well as explicitly requesting specific events), as the following example shows:
 
-```Java
+```java
 @Bean
 public BrokerEventListener eventListener() {
     return new BrokerEventListener(connectionFactory(), "user.deleted", "channel.#", "queue.#");
@@ -2860,7 +2860,7 @@ public BrokerEventListener eventListener() {
 
 You can further narrow the received events in individual event listeners, by using normal Spring techniques, as the following example shows:
 
-```Java
+```java
 @EventListener(condition = "event.eventType == 'queue.created'")
 public void listener(BrokerEvent event) {
     ...
@@ -3031,7 +3031,7 @@ This transaction attribute can be used directly in the container or through a tr
 
 The following example uses this rule:
 
-```Java
+```java
 @Bean
 public AbstractMessageListenerContainer container() {
     ...
@@ -3227,7 +3227,7 @@ By default, it uses `MessageProperties` default value - `MessageDeliveryMode.PER
 
 The following example shows how to set a `RepublishMessageRecoverer` as the recoverer:
 
-```Java
+```java
 @Bean
 RetryOperationsInterceptor interceptor() {
     return RetryInterceptorBuilder.stateless()
@@ -3241,7 +3241,7 @@ The `RepublishMessageRecoverer` publishes the message with additional informatio
 Additional headers can be added by creating a subclass and overriding `additionalHeaders()`.
 The `deliveryMode` (or any other properties) can also be changed in the `additionalHeaders()`, as follows:
 
-```Java
+```java
 RepublishMessageRecoverer recoverer = new RepublishMessageRecoverer(amqpTemplate, "error") {
 
     protected Map<? extends String, ? extends Object> additionalHeaders(Message message, Throwable cause) {

--- a/docs/docs/v3/messaging/rabbitmq-reference.md
+++ b/docs/docs/v3/messaging/rabbitmq-reference.md
@@ -1400,7 +1400,6 @@ public void HandleAFoo(Foo foo)
 {
     ....
 }
-
 ```
 
 The container factories provide methods for adding `IMessagePostProcessor` instances that are applied after receiving messages (before invoking the listener) and before sending replies.
@@ -1519,7 +1518,6 @@ public class MyRabbitListenerConfigurer : IRabbitListenerConfigurer
         registrar.MessageHandlerMethodFactory = handler;
     }
 }
-
 ```
 
 >IMPORTANT: For multi-method listeners ( see [Multiple Method Listeners](#multiple-method-listeners) ), the method selection is based on the payload of the message *after the message conversion*.
@@ -1532,7 +1530,6 @@ The infrastructure lets you configure endpoints programmatically in addition to 
 The following example shows how to do so:
 
 ```csharp
-
 ...
 // Add core services
 services.AddRabbitServices();
@@ -1561,7 +1558,6 @@ public class MyRabbitEndpointConfigurer : IRabbitListenerConfigurer
         registrar.RegisterEndpoint(endpoint);
     }
 }
-
 ```
 
 In the preceding example, we used `SimpleRabbitListenerEndpoint`, which provides the actual `IMessageListener` to invoke, but you could just as well build your own endpoint variant to describe a custom invocation mechanism.
@@ -1687,7 +1683,6 @@ Alternatively, you can use a `IMessagePostProcessor` in the `BeforeSendReplyMess
 The called type and method is made available in the reply message, which can be used in a message post processor to communicate the information back to the caller:
 
 ```csharp
-
 // Configure default container factory with post processor
 services.AddRabbitListenerContainerFactory((p, f) =>
 {
@@ -1709,13 +1704,11 @@ public class AddSomeHeadersPostProcessor : IMessagePostProcessor
         return PostProcessMessage(message, null);
     }
 }
-
 ```
 
 You can configure a `IReplyPostProcessor` on the `[RabbitListener()]` attribute to modify the reply message before it is sent as well; it is called after the `correlationId` header has been set up to match the request.
 
 ```csharp
-
 // Add the reply post processor to the container .. has name set to echoCustomHeader
 services.AddSingleton<IReplyPostProcessor, MyReplyPostProcessor>();
 
@@ -1935,7 +1928,6 @@ When receiving a [batch](#batching) of messages, the de-batching is normally per
 You can configure the listener container factory and listener to receive the entire batch in one call, simply set the factory's `BatchListener` property, and make the method payload parameter a `List`:
 
 ```csharp
-
 // Configure the default container factory for batch listening
 services.AddRabbitListenerContainerFactory((p, f) =>
 {
@@ -1981,7 +1973,6 @@ There are two ways to create such containers:
 The following example uses a `SimpleRabbitListenerEndpoint` to create a listener container:
 
 ```csharp
-
 // Add core services
 services.AddRabbitHostingServices();
 services.AddRabbitDefaultMessageConverter();
@@ -2010,7 +2001,6 @@ services.AddRabbitDirecListenerContainer((p) =>
 The following example adds the listener after creation:
 
 ```csharp
-
 // Add core services
 services.AddRabbitHostingServices();
 services.AddRabbitDefaultMessageConverter();
@@ -2032,7 +2022,6 @@ services.AddRabbitDirecListenerContainer((p) =>
 
     return container;
 });
-
 ```
 
 In either case, the listener can also be a `IChannelAwareMessageListener`, since it is now a sub-interface of `IMessageListener`.
@@ -2081,7 +2070,6 @@ services.AddRabbitDirecListenerContainer("container", (p, container) =>
    container.MissingQueuesFatal = false;
    container.Initialize();
 });
-
 ```
 
 When the `RabbitAdmin` declares queues, it updates the `Queue.ActualName` property with the name returned by the broker.
@@ -2611,7 +2599,6 @@ that has both client and server configuration needs.
 The following listing shows the code for the sample:
 
 ```csharp
-
 // Configuration code common to both client and server
 
 services.ConfigureRabbitOptions(Configuration);
@@ -2692,7 +2679,6 @@ var fooExchange = ExchangeBuilder.DirectExchange("foo")
       .AutoDelete()
       .WithArgument("foo", "bar")
       .Build();
-
 ```
 
 See the code for [QueueBuilder](https://github.com/SteeltoeOSS/Steeltoe/blob/release/3.2/src/Messaging/src/RabbitMQ/Config/QueueBuilder.cs) and [ExchangeBuilder](https://github.com/SteeltoeOSS/Steeltoe/blob/release/3.2/src/Messaging/src/RabbitMQ/Config/ExchangeBuilder.cs) for more information.
@@ -2721,7 +2707,6 @@ var alternate = ExchangeBuilder.DirectExchange("ex.with.alternate")
             .Durable(true)
             .Alternate("alternate")
             .Build();
-
 ```
 
 ### Declaring Collections of Exchanges Queues and Bindings
@@ -2808,7 +2793,6 @@ services.AddRabbitBinding("foo.binding", Binding.DestinationType.QUEUE, (p, b) =
     var admin1 = p.GetRabbitAdmin("admin1");
     binding.SetAdminsThatShouldDeclare(admin1);
 });
-
 ```
 
 ### A Note On the `ServiceName` and `*Name` Properties

--- a/docs/docs/v3/stream/data-flow-stream.md
+++ b/docs/docs/v3/stream/data-flow-stream.md
@@ -39,31 +39,31 @@ Spring Cloud team publishes a number of sample applications as `maven` and `dock
 
 <!-- For the `UsageDetailSender` source, use one of the following:
 
-```
+```text
 maven://io.spring.dataflow.sample:usage-detail-sender-rabbit:0.0.1-SNAPSHOT
 ```
 
-```
+```text
 docker://springcloudstream/usage-detail-sender-rabbit:0.0.1-SNAPSHOT
 ```
 
 For the `UsageCostProcessor` processor, use one of the following:
 
-```
+```text
 maven://io.spring.dataflow.sample:usage-cost-processor-rabbit:0.0.1-SNAPSHOT
 ```
 
-```
+```text
 docker://springcloudstream/usage-cost-processor-rabbit:0.0.1-SNAPSHOT
 ```
 
 For the `UsageCostLogger` sink, use one of the following:
 
-```
+```text
 maven://io.spring.dataflow.sample:usage-cost-logger-rabbit:0.0.1-SNAPSHOT
 ```
 
-```
+```text
 docker://springcloudstream/usage-cost-logger-rabbit:0.0.1-SNAPSHOT
 ```
 -->
@@ -203,7 +203,7 @@ If you run SCDF on Docker, to access the log files of the streaming applications
 
 `docker exec <stream-application-docker-container-id> tail -f <stream-application-log-file>`
 
-```
+```text
 2019-04-19 22:16:04.864  INFO 95238 --- [container-0-C-1] c.e.demo.UsageCostLoggerApplication      : {"userId": "Mark", "callCost": "0.17", "dataCost": "0.32800000000000007" }
 2019-04-19 22:16:04.872  INFO 95238 --- [container-0-C-1] c.e.demo.UsageCostLoggerApplication      : {"userId": "Janne", "callCost": "0.20800000000000002", "dataCost": "0.298" }
 2019-04-19 22:16:04.872  INFO 95238 --- [container-0-C-1] c.e.demo.UsageCostLoggerApplication      : {"userId": "Ilaya", "callCost": "0.175", "dataCost": "0.16150000000000003" }

--- a/docs/docs/v3/stream/data-flow-stream.md
+++ b/docs/docs/v3/stream/data-flow-stream.md
@@ -232,7 +232,7 @@ Besides verifying the runtime status of your stream, you should also verify the 
 To run data through the stream, POST data to the HttpSource application using a client such as [Httpie](https://httpie.io/) and verify the logs for the transformed output.
 
 ```bash
- http --json POST https://mkzmlko-steeltoestream-http-v1.apps.pcfone.io/ test=data
+http --json POST https://mkzmlko-steeltoestream-http-v1.apps.pcfone.io/ test=data
 ```
 
  The logging statements should look like the following:
@@ -276,7 +276,7 @@ Once you have registered the applications, you can deploy the stream per the ins
 
 To lists the pods (including the server components and the streaming applications), run the following command (shown with its output):
 
-```bash
+```shell
  kubectl get pods
 ```
 
@@ -300,9 +300,7 @@ The following example (shown with its output) shows how to make sure that the va
 
 ```bash
 kubectl port-forward --namespace default svc/steeltoestream-http 8081:8080
-
 http --json POST http://localhost:8081 "test=data"
-
 kubectl logs steeltoestream-steeltoebasicsink-v2-5fd5c84448-f2w5b
 ```
 

--- a/docs/docs/v3/stream/data-flow-stream.md
+++ b/docs/docs/v3/stream/data-flow-stream.md
@@ -65,7 +65,8 @@ maven://io.spring.dataflow.sample:usage-cost-logger-rabbit:0.0.1-SNAPSHOT
 
 ```
 docker://springcloudstream/usage-cost-logger-rabbit:0.0.1-SNAPSHOT
-``` -->
+```
+-->
 
 ### The Data Flow Dashboard
 
@@ -251,7 +252,6 @@ For the `Http` source, use the following:
 
 ```text
 docker:springcloudstream/http-source-rabbit:3.0.1
-
 ```
 
 For the `BasicStreamProcessor` processor, use the following:
@@ -299,7 +299,6 @@ To run data through the stream you can POST data to the HttpSource application u
 The following example (shown with its output) shows how to make sure that the values you expect appear in the logs:
 
 ```bash
-
 kubectl port-forward --namespace default svc/steeltoestream-http 8081:8080
 
 http --json POST http://localhost:8081 "test=data"

--- a/docs/docs/v3/stream/standalone-stream-rabbitmq.md
+++ b/docs/docs/v3/stream/standalone-stream-rabbitmq.md
@@ -623,7 +623,7 @@ kubectl apply -f https://raw.githubusercontent.com/spring-cloud/spring-cloud-dat
 
 To build the Docker images, we use a Dockerfile for each of the three applications. For example the UsageSender Dockerfile looks like this:
 
-```Dockerfile
+```dockerfile
 FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /source
 

--- a/docs/docs/v3/stream/standalone-stream-rabbitmq.md
+++ b/docs/docs/v3/stream/standalone-stream-rabbitmq.md
@@ -375,7 +375,7 @@ In this section, we deploy the applications created earlier to the local machine
 
 When you deploy these three applications (`UsageDetailSender`, `UsageCostProcessor`, and `UsageCostLogger`), the flow of message is as follows:
 
-```
+```text
 UsageDetailSender -> UsageCostProcessor -> UsageCostLogger
 ```
 
@@ -401,7 +401,7 @@ You can use the default account username and password: `guest` and `guest`.
 
 By using the [pre-defined](#configuration-usage-detail-sender) configuration properties (along with a unique server port) for `UsageSender`, you can run the application, as follows:
 
-```
+```shell
 cd UsageSender
 dotnet build && dotnet run --framework net6.0
 ```
@@ -422,7 +422,7 @@ When configuring the consumer applications for this `Source` application, you ca
 
 By using the [pre-defined](#configuration-usage-cost-processor) configuration properties (along with a unique server port) for `UsageProcessor`, you can run the application, as follows:
 
-```
+```shell
 cd UsageProcessor
 dotnet build && dotnet run --framework net6.0
 ```
@@ -725,7 +725,7 @@ kubectl apply -f usage-cost-stream.yaml
 
 If all is well, you should see the following output:
 
-```
+```text
 pod/usage-detail-sender created
 pod/usage-cost-processor created
 pod/usage-cost-logger created

--- a/docs/docs/v3/stream/standalone-stream-rabbitmq.md
+++ b/docs/docs/v3/stream/standalone-stream-rabbitmq.md
@@ -67,7 +67,6 @@ Now we can create the code required for this application. To do so:
 1. Create the `UsageGenerator` class in the project, which resembles the following listing:
 
 ```csharp
-
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Steeltoe.Messaging;
@@ -250,7 +249,6 @@ namespace UsageProcessor
         }
     }
 }
-
 ```
 
 In the preceding application, the `[EnableBinding]` attribute indicates that you want to bind your application to the messaging middleware. The attribute takes one or more interfaces as a parameter, in this case, the [IProcessor](https://github.com/SteeltoeOSS/Steeltoe/blob/main/src/Stream/src/Abstractions/Messaging/IProcessor.cs) that defines and input and output channel.
@@ -573,7 +571,6 @@ cf apps
 The following listings shows typical output:
 
 ```bash
-
 name              requested state   processes   routes
 usage-logger      started           web:1/1     usage-logger.apps.pcfone.io
 usage-processor   started           web:1/1     usage-processor.apps.pcfone.io
@@ -627,7 +624,6 @@ kubectl apply -f https://raw.githubusercontent.com/spring-cloud/spring-cloud-dat
 To build the Docker images, we use a Dockerfile for each of the three applications. For example the UsageSender Dockerfile looks like this:
 
 ```Dockerfile
-
 FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /source
 
@@ -645,7 +641,6 @@ ENV SPRING_RABBITMQ_HOST=host.docker.internal
 ENV PORT=8080
 
 ENTRYPOINT ["dotnet", "UsageSender.dll"]
-
 ```
 
 Then use the `docker build` command to build, tag and publish to your repository:

--- a/docs/docs/v3/stream/standalone-stream-rabbitmq.md
+++ b/docs/docs/v3/stream/standalone-stream-rabbitmq.md
@@ -390,7 +390,7 @@ You can run the applications as standalone applications on your `local` environm
 
 To install and run the `RabbitMQ` docker image, run the following command:
 
-```bash
+```shell
 docker run -d --hostname rabbitmq --name rabbitmq -p 15672:15672 -p 5672:5672 rabbitmq:3.7.14-management
 ```
 
@@ -445,14 +445,14 @@ Also, if you click on the `Queues` and check the `usage-cost.logger` queue, you 
 
 By using the [pre-defined](#configuration-usage-cost-logger) configuration properties (along with a unique server port) for `UsageLogger`, you can run the application, as follows:
 
-```bash
+```shell
 cd UsageLogger
 dotnet build && dotnet run --framework net6.0
 ```
 
 Now you can see that this application logs the usage cost detail it receives from the `usage-cost` RabbitMQ exchange through the `usage-cost.logger` durable queue, as the following example shows:
 
-```cmd
+```text
 info: UsageLogger.UsageLogger[0]
       Received UsageCostDetail { "UserId" "user3", "CallCost": "$12.90", "DataCost": "$28.95" }
 info: UsageLogger.UsageLogger[0]
@@ -482,7 +482,7 @@ To create a RabbitMQ service:
 1. Log in to the CloudFoundry environment with your credentials.
 1. From the CF market place, create a RabbitMQ service instance.
 
-```bash
+```shell
 cf create-service p-rabbitmq standard stream-rabbitmq
 ```
 
@@ -508,7 +508,7 @@ applications:
 
 Push the `UsageDetailSender` application by using its manifest YAML file, as follows:
 
-```bash
+```shell
 cd UsageSender
 dotnet publish -f net6.0 -r linux-x64 -o publish
 cf push -f manifest.yml
@@ -532,7 +532,7 @@ applications:
 
 Push the `UsageProcessor` application by using its manifest YAML file, as follows:
 
-```bash
+```shell
 cd UsageProcessor
 dotnet publish -f net6.0 -r linux-x64 -o publish
 cf push -f manifest.yml
@@ -556,7 +556,7 @@ applications:
 
 Push the `UsageLogger` application by using its manifest YAML file, as follows:
 
-```bash
+```shell
 cd UsageLogger
 dotnet publish -f net6.0 -r linux-x64 -o publish
 cf push -f manifest.yml
@@ -564,28 +564,28 @@ cf push -f manifest.yml
 
 You can see the applications running by using the `cf apps` command, as follows:
 
-```bash
+```shell
 cf apps
 ```
 
 The following listings shows typical output:
 
-```bash
+```text
 name              requested state   processes   routes
 usage-logger      started           web:1/1     usage-logger.apps.pcfone.io
 usage-processor   started           web:1/1     usage-processor.apps.pcfone.io
 usage-sender      started           web:1/1     usage-sender.apps.pcfone.io
 ```
 
-```cmd
-   2021-06-08T15:39:57.62-0400 [APP/PROC/WEB/0] OUT info: UsageLogger.UsageLogger[0]
-   2021-06-08T15:39:57.62-0400 [APP/PROC/WEB/0] OUT       Received UsageCostDetail { "UserId" "user4", "CallCost": "$21.30", "DataCost": "$31.40" }
-   2021-06-08T15:40:02.63-0400 [APP/PROC/WEB/0] OUT info: UsageLogger.UsageLogger[0]
-   2021-06-08T15:40:02.63-0400 [APP/PROC/WEB/0] OUT       Received UsageCostDetail { "UserId" "user3", "CallCost": "$1.30", "DataCost": "$27.20" }
-   2021-06-08T15:40:07.63-0400 [APP/PROC/WEB/0] OUT info: UsageLogger.UsageLogger[0]
-   2021-06-08T15:40:07.63-0400 [APP/PROC/WEB/0] OUT       Received UsageCostDetail { "UserId" "user2", "CallCost": "$5.60", "DataCost": "$29.30" }
-   2021-06-08T15:40:12.62-0400 [APP/PROC/WEB/0] OUT info: UsageLogger.UsageLogger[0]
-   2021-06-08T15:40:12.62-0400 [APP/PROC/WEB/0] OUT       Received UsageCostDetail { "UserId" "user4", "CallCost": "$0.40", "DataCost": "$26.15" }
+```text
+2021-06-08T15:39:57.62-0400 [APP/PROC/WEB/0] OUT info: UsageLogger.UsageLogger[0]
+2021-06-08T15:39:57.62-0400 [APP/PROC/WEB/0] OUT       Received UsageCostDetail { "UserId" "user4", "CallCost": "$21.30", "DataCost": "$31.40" }
+2021-06-08T15:40:02.63-0400 [APP/PROC/WEB/0] OUT info: UsageLogger.UsageLogger[0]
+2021-06-08T15:40:02.63-0400 [APP/PROC/WEB/0] OUT       Received UsageCostDetail { "UserId" "user3", "CallCost": "$1.30", "DataCost": "$27.20" }
+2021-06-08T15:40:07.63-0400 [APP/PROC/WEB/0] OUT info: UsageLogger.UsageLogger[0]
+2021-06-08T15:40:07.63-0400 [APP/PROC/WEB/0] OUT       Received UsageCostDetail { "UserId" "user2", "CallCost": "$5.60", "DataCost": "$29.30" }
+2021-06-08T15:40:12.62-0400 [APP/PROC/WEB/0] OUT info: UsageLogger.UsageLogger[0]
+2021-06-08T15:40:12.62-0400 [APP/PROC/WEB/0] OUT       Received UsageCostDetail { "UserId" "user4", "CallCost": "$0.40", "DataCost": "$26.15" }
 ```
 
 ### Running on Kubernetes
@@ -600,9 +600,11 @@ For this example, we need a running Kubernetes cluster. For this example, we dep
 
 To verify that you have a running Kubernetes instance, run the following command (show with sample output):
 
-```bash
+```shell
 kubectl config get-contexts
+```
 
+```text
 CURRENT   NAME             CLUSTER          AUTHINFO         NAMESPACE
 *         docker-desktop   docker-desktop   docker-desktop
 
@@ -615,7 +617,7 @@ Switched to context "docker-desktop".
 You can install the RabbitMQ message broker by using the default configuration from Spring Cloud Data Flow.
 To do so, run the following command:
 
-```bash
+```shell
 kubectl apply -f https://raw.githubusercontent.com/spring-cloud/spring-cloud-dataflow/main/src/kubernetes/rabbitmq/rabbitmq-deployment.yaml -f https://raw.githubusercontent.com/spring-cloud/spring-cloud-dataflow/main/src/kubernetes/rabbitmq/rabbitmq-svc.yaml
 ```
 
@@ -645,7 +647,7 @@ ENTRYPOINT ["dotnet", "UsageSender.dll"]
 
 Then use the `docker build` command to build, tag and publish to your repository:
 
-```bash
+```shell
 docker build . -t <your-repo>/usagelogger
 ```
 
@@ -719,7 +721,7 @@ spec:
 
 Then you can deploy the apps, as follows:
 
-```bash
+```shell
 kubectl apply -f usage-cost-stream.yaml
 ```
 
@@ -739,13 +741,13 @@ We set the logical hostname for the RabbitMQ broker for each app to connect to i
 
 To verify the deployment, use the following command to tail the log for the `usage-cost-logger` sink:
 
-```bash
+```shell
 kubectl logs -f usage-logger
 ```
 
 You should see messages similar to the following streaming:
 
-```cmd
+```text
 info: UsageLogger.UsageLogger[0]
       Received UsageCostDetail { "UserId" "user3", "CallCost": "$12.90", "DataCost": "$28.95" }
 info: UsageLogger.UsageLogger[0]
@@ -760,13 +762,13 @@ info: UsageLogger.UsageLogger[0]
 
 To delete the stream, we can use the label we created earlier, as follows:
 
-```bash
+```shell
 kubectl delete pod -l app=usage-cost-stream
 ```
 
 To uninstall RabbitMQ, run the following command:
 
-```bash
+```shell
 kubectl delete all -l app=rabbitmq
 ```
 

--- a/docs/docs/v3/stream/stream-reference.md
+++ b/docs/docs/v3/stream/stream-reference.md
@@ -554,7 +554,6 @@ When implementing polled consumers, you are required to poll the `IPollableMessa
 Consider the following example of a polled consumer:
 
 ```csharp
-
 public interface IPolledConsumerBinding
 {
     [Input]
@@ -576,7 +575,6 @@ public class Program
         await host.StartAsync();
     }
 }
-
 ```
 
 Given the polled consumer in the preceding example, you might use it as follows:

--- a/docs/docs/v3/tracing/index.md
+++ b/docs/docs/v3/tracing/index.md
@@ -45,10 +45,10 @@ To add this type of NuGet to your project, add a `PackageReference` resembling t
 </ItemGroup>
 ```
 
-Alternative, you can add it with PowerShell:
+Or, from the command line:
 
-```powershell
-PM>Install-Package Steeltoe.Management.TracingCore
+```shell
+dotnet add package Steeltoe.Management.TracingCore --version 3.2.0
 ```
 
 ### Configure Settings

--- a/docs/docs/v3/welcome/common-steps.md
+++ b/docs/docs/v3/welcome/common-steps.md
@@ -29,7 +29,6 @@ cf push -f manifest.yml -p bin/Debug/net6.0/linux-x64/publish
 
 # Push to Windows cell, .NET Core
 cf push -f manifest-windows.yml -p bin/Debug/net6.0/win-x64/publish
-
 ```
 
 >All sample manifests have been defined to bind their application to the services as created earlier.

--- a/docs/docs/v3/welcome/common-steps.md
+++ b/docs/docs/v3/welcome/common-steps.md
@@ -23,13 +23,17 @@ You can use the `dotnet` CLI to [build and locally publish](https://docs.microso
 
 This section describes how to use the Cloud Foundry CLI to push the published application to Cloud Foundry by using the parameters that match what you selected for framework and runtime:
 
-```bash
-# Push to Linux cell
-cf push -f manifest.yml -p bin/Debug/net6.0/linux-x64/publish
+- Push to Linux cell:
 
-# Push to Windows cell, .NET Core
-cf push -f manifest-windows.yml -p bin/Debug/net6.0/win-x64/publish
-```
+  ```shell
+  cf push -f manifest.yml -p bin/Debug/net6.0/linux-x64/publish
+  ```
+
+- Push to Windows cell:
+
+  ```shell
+  cf push -f manifest-windows.yml -p bin/Debug/net6.0/win-x64/publish
+  ```
 
 >All sample manifests have been defined to bind their application to the services as created earlier.
 
@@ -39,7 +43,7 @@ To see the logs as you startup the application, use `cf logs oauth`.
 
 On a Linux cell, you should see output that resembles the following during startup:
 
-```bash
+```text
 2016-06-01T09:14:14.38-0600 [CELL/0]     OUT Creating container
 2016-06-01T09:14:15.93-0600 [CELL/0]     OUT Successfully created container
 2016-06-01T09:14:17.14-0600 [CELL/0]     OUT Starting health monitoring of container

--- a/docs/docs/v4/configuration/config-server-provider.md
+++ b/docs/docs/v4/configuration/config-server-provider.md
@@ -129,21 +129,31 @@ builder.AddConfigServer();
 
 ### Bind to Cloud Foundry
 
-When you want to use a Config Server on Cloud Foundry and you have installed [Spring Cloud Services](https://github.com/SteeltoeOSS/Samples/blob/main/CommonTasks.md#provision-sccs-on-cloud-foundry), you can create and bind an instance of it to your application by using the Cloud Foundry CLI, as follows:
+When you want to use a Config Server on Cloud Foundry and you have installed [Spring Cloud Services](https://github.com/SteeltoeOSS/Samples/blob/main/CommonTasks.md#provision-sccs-on-cloud-foundry), you can create and bind an instance of it to your application by using the Cloud Foundry CLI.
 
-```shell
-# Create a Config Server instance named `myConfigServer`
-cf create-service p-config-server standard myConfigServer
+1. Create a Config Server instance:
 
-# Wait for service to become ready
-cf services
+   ```shell
+   cf create-service p-config-server standard myConfigServer
+   ```
 
-# Bind the service to `myApp`
-cf bind-service myApp myConfigServer
+1. Wait for service to become ready:
 
-# Restage the app to pick up change
-cf restage myApp
-```
+   ```shell
+   cf services
+   ```
+
+1. Bind service to your app:
+
+   ```shell
+   cf bind-service myApp myConfigServer
+   ```
+
+1. Restage the app to pick up change:
+
+   ```shell
+   cf restage myApp
+   ```
 
 After the service is bound to the application, the Config Server settings are available and can be set up in `VCAP_SERVICES`.
 

--- a/docs/docs/v4/connectors/cosmosdb.md
+++ b/docs/docs/v4/connectors/cosmosdb.md
@@ -130,15 +130,23 @@ This Connector supports the following service brokers:
 
 - [VMware Tanzu Cloud Service Broker for Azure](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/tanzu-cloud-service-broker-for-microsoft-azure/1-10/csb-azure/index.html)
 
-You can create and bind an instance to your application by using the Cloud Foundry CLI:
+You can create and bind an instance to your application by using the Cloud Foundry CLI.
 
-```shell
-# Create CosmosDB service
-cf create-service csb-azure-cosmosdb-sql mini myCosmosDbService
+1. Create CosmosDB service:
 
-# Bind service to your app
-cf bind-service myApp myCosmosDbService
+   ```shell
+   cf create-service csb-azure-cosmosdb-sql mini myCosmosDbService
+   ```
 
-# Restage the app to pick up change
-cf restage myApp
-```
+1. Bind service to your app:
+
+   ```shell
+   cf bind-service myApp myCosmosDbService
+   ```
+
+1. Restage the app to pick up change:
+
+   ```shell
+   cf restage myApp
+   ```
+

--- a/docs/docs/v4/connectors/microsoft-sql-server.md
+++ b/docs/docs/v4/connectors/microsoft-sql-server.md
@@ -148,15 +148,23 @@ This Connector supports the following service brokers:
 
 - [VMware Tanzu Cloud Service Broker for Azure](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/tanzu-cloud-service-broker-for-microsoft-azure/1-12/csb-azure/index.html)
 
-You can create and bind an instance to your application by using the Cloud Foundry CLI:
+You can create and bind an instance to your application by using the Cloud Foundry CLI.
 
-```shell
-# Create SQL Server service
-cf create-service csb-azure-mssql small-v2 mySqlServerService
+1. Create SQL Server service:
 
-# Bind service to your app
-cf bind-service myApp mySqlServerService
+   ```shell
+   cf create-service csb-azure-mssql small-v2 mySqlServerService
+   ```
 
-# Restage the app to pick up change
-cf restage myApp
-```
+1. Bind service to your app:
+
+   ```shell
+   cf bind-service myApp mySqlServerService
+   ```
+
+1. Restage the app to pick up change:
+
+   ```shell
+   cf restage myApp
+   ```
+

--- a/docs/docs/v4/connectors/mongodb.md
+++ b/docs/docs/v4/connectors/mongodb.md
@@ -106,18 +106,25 @@ This Connector supports the following service brokers:
 
 - [VMware Tanzu Cloud Service Broker for Azure](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/tanzu-cloud-service-broker-for-microsoft-azure/1-12/csb-azure/index.html)
 
-You can create and bind an instance to your application by using the Cloud Foundry CLI:
+You can create and bind an instance to your application by using the Cloud Foundry CLI.
 
-```shell
-# Create MongoDB service
-cf create-service csb-azure-mongodb small myMongoDbService
+1. Create MongoDB service:
 
-# Bind service to your app
-cf bind-service myApp myMongoDbService
+   ```shell
+   cf create-service csb-azure-mongodb small myMongoDbService
+   ```
 
-# Restage the app to pick up change
-cf restage myApp
-```
+1. Bind service to your app:
+
+   ```shell
+   cf bind-service myApp myMongoDbService
+   ```
+
+1. Restage the app to pick up change:
+
+   ```shell
+   cf restage myApp
+   ```
 
 ## Kubernetes
 

--- a/docs/docs/v4/connectors/mysql.md
+++ b/docs/docs/v4/connectors/mysql.md
@@ -156,18 +156,25 @@ This Connector supports the following service brokers:
 - [VMware Tanzu Cloud Service Broker for Azure](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/tanzu-cloud-service-broker-for-microsoft-azure/1-9/csb-azure/index.html)
 - [VMware Tanzu Cloud Service Broker for GCP](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/tanzu-cloud-service-broker-for-gcp/1-8/csb-gcp/index.html)
 
-You can create and bind an instance to your application by using the Cloud Foundry CLI:
+You can create and bind an instance to your application by using the Cloud Foundry CLI.
 
-```shell
-# Create MySQL service
-cf create-service p.mysql db-small myMySqlService
+1. Create MySQL service:
 
-# Bind service to your app
-cf bind-service myApp myMySqlService
+   ```shell
+   cf create-service p.mysql db-small myMySqlService
+   ```
 
-# Restage the app to pick up change
-cf restage myApp
-```
+1. Bind service to your app:
+
+   ```shell
+   cf bind-service myApp myMySqlService
+   ```
+
+1. Restage the app to pick up change:
+
+   ```shell
+   cf restage myApp
+   ```
 
 ## Kubernetes
 

--- a/docs/docs/v4/connectors/postgresql.md
+++ b/docs/docs/v4/connectors/postgresql.md
@@ -150,18 +150,25 @@ This Connector supports the following service brokers:
 - [VMware Tanzu Cloud Service Broker for Azure](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/tanzu-cloud-service-broker-for-microsoft-azure/1-9/csb-azure/index.html)
 - [VMware Tanzu Cloud Service Broker for GCP](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/tanzu-cloud-service-broker-for-gcp/1-8/csb-gcp/index.html)
 
-You can create and bind an instance to your application by using the Cloud Foundry CLI:
+You can create and bind an instance to your application by using the Cloud Foundry CLI.
 
-```shell
-# Create PostgreSQL service
-cf create-service csb-azure-postgresql small myPostgreSqlService
+1. Create PostgreSQL service:
 
-# Bind service to your app
-cf bind-service myApp myPostgreSqlService
+   ```shell
+   cf create-service csb-azure-postgresql small myPostgreSqlService
+   ```
 
-# Restage the app to pick up change
-cf restage myApp
-```
+1. Bind service to your app:
+
+   ```shell
+   cf bind-service myApp myPostgreSqlService
+   ```
+
+1. Restage the app to pick up change:
+
+   ```shell
+   cf restage myApp
+   ```
 
 ## Kubernetes
 

--- a/docs/docs/v4/connectors/rabbitmq.md
+++ b/docs/docs/v4/connectors/rabbitmq.md
@@ -91,18 +91,25 @@ This Connector supports the following service brokers:
 
 - [VMware Tanzu RabbitMQ on Cloud Foundry](https://techdocs.broadcom.com/us/en/vmware-tanzu/data-solutions/tanzu-rabbitmq-on-cloud-foundry/10-0/tanzu-rabbitmq-cloud-foundry/index.html)
 
-You can create and bind an instance to your application by using the Cloud Foundry CLI:
+You can create and bind an instance to your application by using the Cloud Foundry CLI.
 
-```shell
-# Create RabbitMQ service
-cf create-service p.rabbitmq single-node myRabbitMQService
+1. Create RabbitMQ service:
 
-# Bind service to your app
-cf bind-service myApp myRabbitMQService
+   ```shell
+   cf create-service p.rabbitmq single-node myRabbitMQService
+   ```
 
-# Restage the app to pick up change
-cf restage myApp
-```
+1. Bind service to your app:
+
+   ```shell
+   cf bind-service myApp myRabbitMQService
+   ```
+
+1. Restage the app to pick up change:
+
+   ```shell
+   cf restage myApp
+   ```
 
 ## Kubernetes
 

--- a/docs/docs/v4/connectors/redis.md
+++ b/docs/docs/v4/connectors/redis.md
@@ -122,18 +122,25 @@ This Connector supports the following service brokers:
 - [VMware Tanzu Cloud Service Broker for Azure](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/tanzu-cloud-service-broker-for-microsoft-azure/1-12/csb-azure/index.html)
 - [VMware Tanzu Cloud Service Broker for GCP](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/tanzu-cloud-service-broker-for-gcp/1-5/csb-gcp/index.html)
 
-You can create and bind an instance to your application by using the Cloud Foundry CLI:
+You can create and bind an instance to your application by using the Cloud Foundry CLI.
 
-```shell
-# Create Redis service
-cf create-service p-redis shared-vm myRedisService
+1. Create Redis service:
 
-# Bind service to your app
-cf bind-service myApp myRedisService
+   ```shell
+   cf create-service p-redis shared-vm myRedisService
+   ```
 
-# Restage the app to pick up change
-cf restage myApp
-```
+1. Bind service to your app:
+
+   ```shell
+   cf bind-service myApp myRedisService
+   ```
+
+1. Restage the app to pick up change:
+
+   ```shell
+   cf restage myApp
+   ```
 
 ## Kubernetes
 

--- a/docs/docs/v4/connectors/usage.md
+++ b/docs/docs/v4/connectors/usage.md
@@ -48,7 +48,7 @@ Console.WriteLine(options.Value.ConnectionString);
 
 The output is:
 
-```
+```text
 Host=localhost;Database=steeltoe;Username=steeltoe;Password=steeltoe;Log Parameters=True
 ```
 
@@ -252,7 +252,7 @@ public class AppDbContext : DbContext
 
 This is the output:
 
-```
+```text
 Data Source=(localdb)\mssqllocaldb;Initial Catalog=ExampleDB;Pooling=True
 ```
 

--- a/docs/docs/v4/initializr/initializr-service.md
+++ b/docs/docs/v4/initializr/initializr-service.md
@@ -12,9 +12,13 @@ The InitializrService provides four REST/HTTP endpoints:
 `api/` accepts `GET` requests and returns a help document.
 The document includes available parameters (and their defaults) and dependencies, plus CLI samples.
 
-```shell
-# sample: view help doc
-$ http -p b https://start.steeltoe.io/api/
+### Sample: view help doc
+
+```bash
+http -p b https://start.steeltoe.io/api/
+```
+
+```text
 ...
 This service generates quickstart projects that can be easily customized.
 Possible customizations include a project's dependencies and .NET target framework.
@@ -32,9 +36,10 @@ The URI templates take a set of parameters to customize the result of a request.
 
 `api/about` accepts `GET` requests and returns the InitializrService "About" information.
 
-```shell
-# sample: view "About" document
-$ http -p b https://start.steeltoe.io/api/about
+### Sample: View "About" document
+
+```bash
+http -p b https://start.steeltoe.io/api/about
 {
     "commit": "381bbd2a1e30d621ed6ad4a07790955447ffe468",
     "name": "Steeltoe.InitializrApi",
@@ -61,9 +66,10 @@ The following endpoints can be used by CLI users to browse project configuration
 * `api/config/languages`
 * `api/config/steeltoeVersions`
 
-```shell
-# sample: list available Steeltoe versions
-$ http -p b https://start.steeltoe.io/api/config/steeltoeVersions
+### Sample: List available Steeltoe versions
+
+```bash
+http -p b https://start.steeltoe.io/api/config/steeltoeVersions
 [
     {
         "id": "2.4.4",
@@ -78,9 +84,15 @@ $ http -p b https://start.steeltoe.io/api/config/steeltoeVersions
         "name": "Steeltoe 3.0.1 Maintenance Release"
     }
 ]
+```
 
-# sample: list available dependency IDs
-$ http https://start.steeltoe.io/api/config/dependencies | jq '.[] .values[] .id' | sort
+### Sample: List available dependency IDs
+
+```bash
+http https://start.steeltoe.io/api/config/dependencies | jq '.[] .values[] .id' | sort
+```
+
+```text
 "actuator"
 "amqp"
 "azure-spring-cloud"
@@ -111,7 +123,8 @@ The parameter `dependencies` is different than other parameters in that it is se
 > [!TIP]
 > To get a list of parameters and dependencies, send a `GET` request to `api/`.
 
-```shell
-# sample: generate a .NET Core App 3.1 project with actuator endpoints and a Redis backend:
-$ http https://start.steeltoe.io/api/project dotNetFramework=netcoreapp3.1 dependencies==actuators,redis -d
+### Sample: Generate a .NET 8 project with actuator endpoints and a Redis backend
+
+```bash
+http https://start.steeltoe.io/api/project dotNetFramework=net8.0 dependencies==actuators,redis -d
 ```

--- a/docs/docs/v4/management/prometheus.md
+++ b/docs/docs/v4/management/prometheus.md
@@ -115,7 +115,7 @@ You can set up Prometheus to scrape this endpoint by registering your applicatio
 
 As an example, the following `prometheus.yml` file configures metric scraping for a Steeltoe-enabled application listening on port 8091 with the default actuator path:
 
-```yml
+```yaml
 global:
   scrape_interval: 15s # Set the scrape interval to every 15 seconds. The default is every 1 minute.
   evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.

--- a/docs/docs/v4/management/tasks.md
+++ b/docs/docs/v4/management/tasks.md
@@ -103,7 +103,7 @@ await app.RunWithTasksAsync(CancellationToken.None);
 After all the setup steps have been completed, any invocation of your application with a configuration value for the `RunTask` key
 runs that task (and shuts down) instead of starting the web application:
 
-```
+```shell
 dotnet run -- RunTask=ExampleTaskName
 ```
 

--- a/docs/docs/v4/security/jwt-bearer.md
+++ b/docs/docs/v4/security/jwt-bearer.md
@@ -193,15 +193,19 @@ applications:
 #### Bind and configure manually
 
 Alternatively, you can bind the instance manually and restage the app with the Cloud Foundry CLI.
-Then you can configure the SSO binding with the web interface:
+Then you can configure the SSO binding with the web interface.
 
-```shell
-# Bind service to your app
-cf bind-service MY_APPLICATION MY_SERVICE_INSTANCE
+1. Bind service to your app:
 
-# Restage the app to pick up change
-cf restage MY_APPLICATION
-```
+   ```shell
+   cf bind-service MY_APPLICATION MY_SERVICE_INSTANCE
+   ```
+
+1. Restage the app to pick up change:
+
+   ```shell
+   cf restage MY_APPLICATION
+   ```
 
 For more information, see:
 

--- a/docs/docs/v4/security/jwt-bearer.md
+++ b/docs/docs/v4/security/jwt-bearer.md
@@ -176,7 +176,7 @@ For information about configuring an app manifest, see the [Single Sign-On docum
 
 Consider this example manifest that names the application and buildpack, and configures properties for the SSO binding:
 
-```yml
+```yaml
 applications:
 - name: steeltoesamplesserver
   buildpacks:

--- a/docs/docs/v4/security/redis-key-storage-provider.md
+++ b/docs/docs/v4/security/redis-key-storage-provider.md
@@ -96,21 +96,31 @@ builder.AddCloudFoundryConfiguration();
 
 To store data protection keys in a Redis/Valkey cache on Cloud Foundry, use a supported [Redis service](../connectors/redis.md#cloud-foundry) to create and bind an instance of Redis/Valkey to your application.
 
-You can complete these steps using the Cloud Foundry command line, as follows:
+You can complete these steps using the Cloud Foundry command line.
 
-```shell
-# Push your app
-cf push sampleApp --buildpack dotnet_core_buildpack
+1. Push your app:
 
-# Create Redis service
-cf create-service p-redis shared-vm sampleRedisService
+   ```shell
+   cf push sampleApp --buildpack dotnet_core_buildpack
+   ```
 
-# Bind service to your app
-cf bind-service sampleApp sampleRedisService
+1. Create Redis service:
 
-# Restage the app to pick up change
-cf restage sampleApp
-```
+   ```shell
+   cf create-service p-redis shared-vm sampleRedisService
+   ```
+
+1. Bind service to your app:
+
+   ```shell
+   cf bind-service sampleApp sampleRedisService
+   ```
+
+1. Restage the app to pick up change:
+
+   ```shell
+   cf restage sampleApp
+   ```
 
 After the service is bound to your application, the configuration settings are available in `VCAP_SERVICES`.
 

--- a/docs/docs/v4/security/sso-open-id.md
+++ b/docs/docs/v4/security/sso-open-id.md
@@ -195,7 +195,7 @@ For information about configuring an app manifest, see the [Single Sign-On docum
 
 Consider this example manifest that names the application and buildpack, and configures properties for the SSO binding:
 
-```yml
+```yaml
 applications:
 - name: steeltoesamplesclient
   buildpacks:

--- a/docs/docs/v4/security/sso-open-id.md
+++ b/docs/docs/v4/security/sso-open-id.md
@@ -213,15 +213,19 @@ applications:
 #### Bind and configure manually
 
 Alternatively, you can bind the instance manually and restage the app with the Cloud Foundry CLI.
-Then you can configure the SSO binding with the web interface:
+Then you can configure the SSO binding with the web interface.
 
-```shell
-# Bind service to your app
-cf bind-service MY_APPLICATION MY_SERVICE_INSTANCE
+1. Bind service to your app:
 
-# Restage the app to pick up change
-cf restage MY_APPLICATION
-```
+   ```shell
+   cf bind-service MY_APPLICATION MY_SERVICE_INSTANCE
+   ```
+
+1. Restage the app to pick up change:
+
+   ```shell
+   cf restage MY_APPLICATION
+   ```
 
 For more information, see:
 

--- a/docs/docs/v4/welcome/common-steps.md
+++ b/docs/docs/v4/welcome/common-steps.md
@@ -22,15 +22,19 @@ You can use the `dotnet` CLI to [build and locally publish](https://learn.micros
 
 ## Cloud Foundry Push Sample
 
-This section describes how to use the [Cloud Foundry CLI](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html) to push the published application to Cloud Foundry using the parameters that match what you selected for framework and runtime:
+This section describes how to use the [Cloud Foundry CLI](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html) to push the published application to Cloud Foundry using the parameters that match what you selected for framework and runtime.
 
-```shell
-# Push to Linux cell
-cf push -f manifest.yml -p bin/Debug/net8.0/linux-x64/publish
+- Push to Linux cell:
 
-# Push to Windows cell
-cf push -f manifest-windows.yml -p bin/Debug/net8.0/win-x64/publish
-```
+  ```shell
+  cf push -f manifest.yml -p bin/Debug/net8.0/linux-x64/publish
+  ```
+
+- Push to Windows cell:
+
+  ```shell
+  cf push -f manifest-windows.yml -p bin/Debug/net8.0/win-x64/publish
+  ```
 
 > [!NOTE]
 > All samples contain manifest files to bind to the services they depend on.
@@ -41,7 +45,7 @@ To see the logs as you start the application, use `cf logs your-app-name`.
 
 On a Linux cell, you should see output similar to the following during startup:
 
-```shell
+```text
 2016-06-01T09:14:14.38-0600 [CELL/0]     OUT Creating container
 2016-06-01T09:14:15.93-0600 [CELL/0]     OUT Successfully created container
 2016-06-01T09:14:17.14-0600 [CELL/0]     OUT Starting health monitoring of container

--- a/docs/guides/application-configuration/cloud-foundry.md
+++ b/docs/guides/application-configuration/cloud-foundry.md
@@ -27,7 +27,7 @@ First, **create a .NET Core WebAPI** that retrieves (configuration) environment 
 
 1. Publish the application locally using the .NET cli. The following command will create a publish folder automatically
 
-   ```powershell
+   ```shell
    dotnet publish -o .\publish <PATH_TO>\CloudFoundryExample.csproj
    ```
 
@@ -47,7 +47,7 @@ First, **create a .NET Core WebAPI** that retrieves (configuration) environment 
 
 1. Push the app to Cloud Foundry
 
-   ```powershell
+   ```shell
    cf push -f <PATH_TO>\manifest.yml -p .\publish
    ```
 

--- a/docs/guides/application-configuration/placeholder.md
+++ b/docs/guides/application-configuration/placeholder.md
@@ -28,7 +28,7 @@ First, **create a .NET Core WebAPI** that has a placeholder implemented
 
 # [.NET cli](#tab/cli)
 
-```powershell
+```shell
 dotnet run <PATH_TO>\PlaceholderExample.csproj
 ```
 

--- a/docs/guides/application-configuration/random-value.md
+++ b/docs/guides/application-configuration/random-value.md
@@ -28,7 +28,7 @@ First, **create a .NET Core WebAPI** that has a placeholder implemented.
 
 # [.NET cli](#tab/cli)
 
-```powershell
+```shell
 dotnet run <PATH_TO>\RandomValueExample.csproj
 ```
 

--- a/docs/guides/application-configuration/spring-config.md
+++ b/docs/guides/application-configuration/spring-config.md
@@ -36,7 +36,7 @@ Next, **add a config file** to the repository.
 
 Then, **start a config server instance** using the [Steeltoe dockerfile](https://github.com/steeltoeoss/dockerfiles).
 
-```bash
+```shell
 docker run -p 8888:8888 steeltoeoss/config-server --spring.cloud.config.server.git.default-label=main --spring.cloud.config.server.git.uri=<NEW_REPO_URL>
 ```
 
@@ -68,7 +68,7 @@ Next, **create a .NET Core WebAPI** that retrieves values from the Spring Config
 
 # [.NET cli](#tab/cli)
 
-```powershell
+```shell
 dotnet run <PATH_TO>\SpringConfigExample.csproj
 ```
 

--- a/docs/guides/application-configuration/spring-config.md
+++ b/docs/guides/application-configuration/spring-config.md
@@ -27,7 +27,7 @@ Next, **add a config file** to the repository.
 1. Create a new file in the repo named `my-values.yml`
 1. Add the following to the file
 
-   ```yml
+   ```yaml
    Value1: some-val
    Value2: another-val
    ```

--- a/docs/guides/circuit-breaker/circuit-breaker.md
+++ b/docs/guides/circuit-breaker/circuit-breaker.md
@@ -22,7 +22,7 @@ This tutorial takes you through setting up a .NET Core application that implemen
 
 1. There are a few images available on Docker Hub that provide basic Hystrix Dashboard functionality. The following image is provided by the Steeltoe team for testing and development:
 
-```bash
+```shell
 docker run --rm -ti -p 7979:7979 --name steeltoe-hystrix steeltoeoss/hystrix-dashboard
 ```
 
@@ -92,7 +92,7 @@ Alternatively, to run a Hystrix Dashboard with Java on your local workstation
 
 # [.NET cli](#tab/cli)
 
-```powershell
+```shell
 dotnet run <PATH_TO>\CircuitBreakerExample.csproj
 ```
 

--- a/docs/guides/cloud-management/distributed-tracing.md
+++ b/docs/guides/cloud-management/distributed-tracing.md
@@ -20,7 +20,7 @@ First, **start a Zipkin instance**. Depending on your hosting platform this is d
 
 1. Using the [Steeltoe dockerfile](https://github.com/steeltoeoss/dockerfiles), start a local instance of Zipkin
 
-   ```powershell
+   ```shell
    docker run --publish 9411:9411 steeltoeoss/zipkin
    ```
 
@@ -51,8 +51,8 @@ Next, **create a .NET Core WebAPI** that interacts with Distributed Tracing
 
 # [.NET cli](#tab/cli)
 
-```powershell
-dotnet run<PATH_TO>\DistributedTracingExample.csproj
+```shell
+dotnet run <PATH_TO>\DistributedTracingExample.csproj
 ```
 
 Navigate to the endpoint (you may need to change the port number) [http://localhost:5000/api/values](http://localhost:5000/api/values)

--- a/docs/guides/cloud-management/endpoints-framework.md
+++ b/docs/guides/cloud-management/endpoints-framework.md
@@ -39,7 +39,7 @@ Next, **install packages** needed
    <img src="/guides/images/open-package-manager-console.png" alt="Visual Studio - Package Manager Console" width="100%">
 1. Install NuGet distributed packages
 
-   ```powershell
+   ```pwsh
    Install-Package Microsoft.Extensions.Configuration
    Install-Package Microsoft.Extensions.Logging
    Install-Package Microsoft.Extensions.Logging.Console

--- a/docs/guides/cloud-management/endpoints-netcore.md
+++ b/docs/guides/cloud-management/endpoints-netcore.md
@@ -49,8 +49,8 @@ This tutorial takes you through setting up a .NET Core application with cloud ma
 
 # [.NET cli](#tab/cli)
 
-```powershell
-dotnet run<PATH_TO>\ManagementEndpointsNetCoreExample.csproj
+```shell
+dotnet run <PATH_TO>\ManagementEndpointsNetCoreExample.csproj
 ```
 
 Navigate to the management endpoints summary page (you may need to change the port number) [http://localhost:5000/actuator](http://localhost:5000/actuator)

--- a/docs/guides/get-to-know-steeltoe/exercise1.md
+++ b/docs/guides/get-to-know-steeltoe/exercise1.md
@@ -44,7 +44,7 @@ At "Additional information", you can keep the default values.
 
 # [.NET CLI](#tab/dotnet-cli)
 
-```powershell
+```shell
 dotnet new webapi -n WebApplication1
 cd WebApplication1
 ```
@@ -53,7 +53,7 @@ To use Visual Studio as your IDE, open the Visual Studio program, choose "Open a
 
 To use VS Code as your IDE:
 
-```powershell
+```shell
 code .
 ```
 
@@ -73,7 +73,7 @@ Finally the `Steeltoe.Management.TracingCore` package and install.
 
 # [.NET CLI](#tab/dotnet-cli)
 
-```powershell
+```shell
 dotnet add package Steeltoe.Management.EndpointCore
 dotnet add package Steeltoe.Management.TracingCore
 ```
@@ -158,7 +158,7 @@ Click the `Debug > Start Debugging` top menu item. You may be prompted to "trust
 
 Executing the below command will start the application. You will see a log message written, telling how to navigate to the application. It should be [https://localhost:7010/weatherforecast](https://localhost:7010/WeatherForecast).
 
-```powershell
+```shell
 dotnet run
 ```
 

--- a/docs/guides/get-to-know-steeltoe/exercise1.md
+++ b/docs/guides/get-to-know-steeltoe/exercise1.md
@@ -193,7 +193,7 @@ Finally, let's look at the log message that was written.
 
 Go back to the terminal window where the application was started. The logs should be streaming. Locate the following line:
 
-```plaintext
+```text
 [WebApplication1, 917e146c942117d2, 917e146c942117d2, true] Hi there
 ```
 

--- a/docs/guides/get-to-know-steeltoe/exercise2.md
+++ b/docs/guides/get-to-know-steeltoe/exercise2.md
@@ -66,7 +66,7 @@ Click the `Debug > Start Debugging` top menu item. You may be prompted to "trust
 
 Executing the below command will start the application. You will see a log message written, telling you how to navigate to the application. It should be [http://localhost:5000/weatherforecast](http://localhost:5000/weatherforecast).
 
-```powershell
+```shell
 dotnet run
 ```
 

--- a/docs/guides/get-to-know-steeltoe/exercise3.md
+++ b/docs/guides/get-to-know-steeltoe/exercise3.md
@@ -41,7 +41,7 @@ Then search for the `Microsoft.EntityFrameworkCore.SqlServer` package and instal
 
 # [.NET CLI](#tab/dotnet-cli)
 
-```powershell
+```shell
 dotnet add package Steeltoe.Connector.EFCore
 dotnet add package Microsoft.EntityFrameworkCore.SqlServer
 ```
@@ -60,7 +60,7 @@ Right-click on the project name in the solution explorer, choose "Add" > "New Fo
 
 # [.NET CLI](#tab/dotnet-cli)
 
-```powershell
+```shell
 mkdir "Models"
 cd "Models"
 ```
@@ -228,7 +228,7 @@ Local installations of SQL Server are usually available on `localhost:1433`. If 
 
 Should you require one, here is an example docker command for running a SQL Server instance:
 
-```powershell
+```shell
 docker run -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=IheartSteeltoe1" -p 1433:1433 -d mcr.microsoft.com/mssql/server:2022-latest
 ```
 
@@ -271,7 +271,7 @@ Click the `Debug > Start Debugging` top menu item. You may be prompted to "trust
 
 Executing the below command will start the application. You will see a log message written, telling you how to navigate to the application. It should be [http://localhost:5000/weatherforecast](http://localhost:5000/weatherforecast).
 
-```powershell
+```shell
 dotnet run
 ```
 

--- a/docs/guides/get-to-know-steeltoe/exercise4.md
+++ b/docs/guides/get-to-know-steeltoe/exercise4.md
@@ -39,7 +39,7 @@ Right-click on the project name in the solution explorer and choose "Manage NuGe
 
 # [.NET CLI](#tab/dotnet-cli)
 
-```powershell
+```shell
 dotnet add package Steeltoe.Extensions.Configuration.ConfigServerCore
 ```
 
@@ -140,7 +140,7 @@ Click the `Debug > Start Debugging` top menu item. You may be prompted to "trust
 
 Executing the below command will start the application. You will see a log message written, telling you how to navigate to the application. It should be [http://localhost:5000/weatherforecast](http://localhost:5000/weatherforecast).
 
-```powershell
+```shell
 dotnet run
 ```
 

--- a/docs/guides/messaging/Tutorials/Tutorial1/Readme.md
+++ b/docs/guides/messaging/Tutorials/Tutorial1/Readme.md
@@ -147,7 +147,6 @@ Next add `Tut1Receiver` to the service container.  `Tu1Receiver` is the componen
 > Note: At this point we have not explained how to tie together the queue, `Tut1Receiver` and the method that gets invoked; that comes next.
 
 ```csharp
-
 // Add the rabbit listener component
 services.AddSingleton<Tut1Receiver>();
 

--- a/docs/guides/messaging/Tutorials/Tutorial1/Readme.md
+++ b/docs/guides/messaging/Tutorials/Tutorial1/Readme.md
@@ -318,25 +318,21 @@ namespace Receiver
 
 We must now build the solution.
 
-```bash
+```shell
 cd tutorials\tutorial1
 dotnet build
 ```
 
 To run the receiver, execute the following commands:
 
-```bash
-# receiver
-
+```shell
 cd receiver
 dotnet run
 ```
 
 Open another shell to run the sender:
 
-```bash
-# sender
-
+```shell
 cd sender
 dotnet run
 ```
@@ -352,7 +348,7 @@ dotnet run
 >
 > On Windows, omit the sudo:
 >
-> ```bash
+> ```cmd
 > rabbitmqctl.bat list_queues
 > ```
 

--- a/docs/guides/messaging/Tutorials/Tutorial2/Readme.md
+++ b/docs/guides/messaging/Tutorials/Tutorial2/Readme.md
@@ -256,7 +256,7 @@ This is how the `RabbitListener` attribute ties the `Receive(..)` method to the 
 
 Compile both projects using `dotnet build`.
 
-```bash
+```shell
 cd tutorials\tutorial2
 dotnet build
 ```

--- a/docs/guides/messaging/Tutorials/Tutorial2/Readme.md
+++ b/docs/guides/messaging/Tutorials/Tutorial2/Readme.md
@@ -278,7 +278,6 @@ dotnet run
 
 cd sender
 dotnet run
-
 ```
 
 Notice how the work that is produced by the sender is distributed across both receivers.

--- a/docs/guides/messaging/Tutorials/Tutorial3/Readme.md
+++ b/docs/guides/messaging/Tutorials/Tutorial3/Readme.md
@@ -261,7 +261,7 @@ namespace Receiver
 >
 > You can list existing bindings using, you guessed it,
 >
-> ```bash
+> ```shell
 > rabbitmqctl list_bindings
 > ```
 
@@ -396,7 +396,7 @@ namespace Receiver
 
 Compile as before and we're ready to execute the fanout sender and receiver.
 
-```bash
+```shell
 cd tutorials\tutorial3
 dotnet build
 ```
@@ -405,18 +405,14 @@ And of course, to execute the tutorial do the following:
 
 To run the receiver, execute the following commands:
 
-```bash
-# receiver
-
+```shell
 cd receiver
 dotnet run
 ```
 
 Open another shell to run the sender:
 
-```bash
-# sender
-
+```shell
 cd sender
 dotnet run
 ```

--- a/docs/guides/messaging/Tutorials/Tutorial4/Readme.md
+++ b/docs/guides/messaging/Tutorials/Tutorial4/Readme.md
@@ -274,21 +274,21 @@ namespace Receiver
 
 Compile as usual, see [tutorial one](../Tutorial1/Readme.md)
 
-```bash
+```shell
 cd tutorials\tutorial4
 dotnet build
 ```
 
 To run the receiver, execute the following commands:
 
-```bash
+```shell
 cd receiver
 dotnet run
 ```
 
 Open another shell to run the sender:
 
-```bash
+```shell
 cd sender
 dotnet run
 ```

--- a/docs/guides/messaging/Tutorials/Tutorial4/Readme.md
+++ b/docs/guides/messaging/Tutorials/Tutorial4/Readme.md
@@ -104,7 +104,6 @@ Here are the `DeclareQueueBinding` attributes that illustrate the above concepts
 [DeclareQueueBinding(Name = "tut.direct.binding.queue1.black", ExchangeName = "tut.direct", RoutingKey = "black", QueueName = "#{@queue1}")]
 [DeclareQueueBinding(Name = "tut.direct.binding.queue2.green", ExchangeName = "tut.direct", RoutingKey = "green", QueueName = "#{@queue2}")]
 [DeclareQueueBinding(Name = "tut.direct.binding.queue2.black", ExchangeName = "tut.direct", RoutingKey = "black", QueueName = "#{@queue2}")]
-
 ```
 
 ## Publishing messages

--- a/docs/guides/messaging/Tutorials/Tutorial5/Readme.md
+++ b/docs/guides/messaging/Tutorials/Tutorial5/Readme.md
@@ -274,21 +274,21 @@ namespace Sender
 
 Compile as usual, see [tutorial one](../Tutorial1/Readme.md)
 
-```bash
+```shell
 cd tutorials\tutorial5
 dotnet build
 ```
 
 To run the receiver, execute the following commands:
 
-```bash
+```shell
 cd receiver
 dotnet run
 ```
 
 Open another shell to run the sender:
 
-```bash
+```shell
 cd sender
 dotnet run
 ```

--- a/docs/guides/messaging/Tutorials/Tutorial6/Readme.md
+++ b/docs/guides/messaging/Tutorials/Tutorial6/Readme.md
@@ -260,21 +260,21 @@ namespace Sender
 
 Compile as usual, see [tutorial one](../Tutorial1/Readme.md)
 
-```bash
+```shell
 cd tutorials\tutorial6
 dotnet build
 ```
 
 To run the server, execute the following commands:
 
-```bash
+```shell
 cd receiver
 dotnet run
 ```
 
 To request a fibonacci number run the client:
 
-```bash
+```shell
 cd sender
 dotnet run
 ```

--- a/docs/guides/messaging/Tutorials/Tutorial7/Readme.md
+++ b/docs/guides/messaging/Tutorials/Tutorial7/Readme.md
@@ -110,7 +110,6 @@ namespace Sender
         }
     }
 }
-
 ```
 
 ## Strategy #1: Publishing Messages Individually
@@ -238,7 +237,6 @@ namespace Sender
 There are two callbacks: one for confirmed messages and one returned messages.
 
 ```csharp
-
 .....
 public void ReturnedMessage(IMessage<byte[]> message, int replyCode, string replyText, string exchange, string routingKey)
 {
@@ -250,7 +248,6 @@ public void Confirm(CorrelationData correlationData, bool ack, string cause)
     _logger.LogInformation($"Confirming message: Id={correlationData.Id}, Acked={ack}, Cause={cause}");
 }
 ....
-
 ```
 
 For the `ReturnedMessage()` callback method to be
@@ -266,13 +263,11 @@ Note that the `CorrelationData` provided in the `Confirm(CorrelationData correla
 The template then returns it as part of the arguments to the `Confirm(...)` callback.
 
 ```csharp
-
 ....
 CorrelationData data = new CorrelationData(id.ToString());
 id++;
 await _rabbitTemplate.ConvertAndSendAsync(Program.QueueName, (object)"Hello World!", data);
 ...
-
 ```
 
 A simple way to correlate messages with sequence numbering consists in using a
@@ -300,7 +295,6 @@ to the constraints in the application and in the overall system. Typical techniq
 The code for the receivers `Program.cs` comes from the first tutorial:
 
 ```csharp
-
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Steeltoe.Messaging.RabbitMQ.Config;

--- a/docs/guides/messaging/Tutorials/Tutorial7/Readme.md
+++ b/docs/guides/messaging/Tutorials/Tutorial7/Readme.md
@@ -447,21 +447,21 @@ namespace Sender
 
 Compile as usual, see [tutorial one](../Tutorial1/Readme.md)
 
-```bash
+```shell
 cd tutorials\tutorial7
 dotnet build
 ```
 
 To run the receiver, execute the following commands:
 
-```bash
+```shell
 cd receiver
 dotnet run
 ```
 
 To watch the confirms come back, run the sender
 
-```bash
+```shell
 cd sender
 dotnet run
 ```

--- a/docs/guides/observability/grafana.md
+++ b/docs/guides/observability/grafana.md
@@ -18,17 +18,17 @@ This tutorial takes you creating a simple Steeltoe app with actuators, logging, 
 
 First, **clone to accompanying repo** that contains all the needed assets
 
-1. ```powershell
+1. ```shell
    git clone https://github.com/steeltoeoss-incubator/observability.git
    ```
 
-1. ```powershell
+1. ```shell
    cd observability/grafana
    ```
 
-1. Have a look at what things are provided: `PS C:\tmp\observability\grafana> ls`
+1. Have a look at what things are provided:
 
-   ```bash
+   ```text
    Name                Description
    ----                ----
    dashboard.json      The Grafana dashboard definition
@@ -122,8 +122,8 @@ Next, **deploy everything** with docker compose
 
 1. Build the image using the provided docker-compose file.
 
-   ```powershell
-   PS C:\tmp\observability\grafana> docker-compose up -d
+   ```shell
+   docker-compose up -d
    ```
 
    > [!NOTE]
@@ -131,7 +131,7 @@ Next, **deploy everything** with docker compose
 
 1. Confirm everything started successfully by running `docker-compose ps` and checking the State. Output should look similar to this:
 
-   ```bash
+   ```text
    Name           Command                        State     Ports
    -----------------------------------------------------------------------------------------------------------
    grafana        /run.sh                          Up      0.0.0.0:3000->3000/tcp

--- a/docs/guides/observability/tanzu.md
+++ b/docs/guides/observability/tanzu.md
@@ -24,7 +24,7 @@ First, **start a Zipkin instance**.
 
 1. Start an instance of Zipkin, named myappmanagerservice
 
-   ```powershell
+   ```shell
    cf push myappmanagerservice --docker-image steeltoeoss/zipkin
    ```
 
@@ -140,7 +140,7 @@ Next, **create a .NET Core WebAPI** with the correct Steeltoe dependencies.
 
 1. Publish the application locally using the .NET cli. The following command will create a publish folder automatically.
 
-   ```powershell
+   ```shell
    dotnet publish -o .\publish <PATH_TO>\TASObservability.csproj
    ```
 
@@ -159,7 +159,7 @@ Next, **create a .NET Core WebAPI** with the correct Steeltoe dependencies.
 
 1. Push the app to Cloud Foundry
 
-   ```powershell
+   ```shell
    cf push -f <PATH_TO>\manifest.yml -p .\publish
    ```
 

--- a/docs/guides/observability/wavefront.md
+++ b/docs/guides/observability/wavefront.md
@@ -22,21 +22,17 @@ You'll need a Wavefront account to complete this guide successfully. [Create a 3
 
 First, **clone to accompanying repo** that contains all the needed assets
 
-1. ```powershell
+1. ```shell
    git clone https://github.com/steeltoeoss-incubator/observability.git
    ```
 
-   ```powershell
+   ```shell
    cd observability/wavefront
    ```
 
-1. Have a look at what things are provided
+1. Have a look at what things are provided:
 
-   ```powershell
-   ls
-   ```
-
-   ```bash
+   ```text
    Name                    Description
    ----                    ----
    dashboard-template.json Wavefront dashboard configuration
@@ -133,13 +129,13 @@ Next, **deploy everything** with docker compose
 
 1. Build the image using the provided docker-compose file
 
-   ```powershell
+   ```shell
    docker-compose up -d
    ```
 
 1. Confirm everything started successfully by running `docker-compose ps` and checking the State. Output should look similar to this:
 
-   ```bash
+   ```text
    Name              Command                         State    Ports
    -----------------------------------------------------------------------------------------------------------------------------
    steeltoe-app      dotnet Grafana_Observabili ...   Up      0.0.0.0:80->80/tcp

--- a/docs/guides/security/redisstore.md
+++ b/docs/guides/security/redisstore.md
@@ -18,7 +18,7 @@ This tutorial takes you through setting up a .NET Core application that stores i
 
 First, **start a Redis instance**. Using the [Steeltoe dockerfile](https://github.com/steeltoeoss/dockerfiles), start a local instance of RedisStore.
 
-```powershell
+```shell
 docker run --publish 6379:6379 steeltoeoss/redis
 ```
 
@@ -60,8 +60,8 @@ Next, **create a .NET Core WebAPI** using redis for key storage
 
 # [.NET cli](#tab/cli)
 
-```powershell
-dotnet run<PATH_TO>\RedisKeyRingExample.csproj
+```shell
+dotnet run <PATH_TO>\RedisKeyRingExample.csproj
 ```
 
 Navigate to the endpoint (you may need to change the port number) [http://localhost:5000/api/values](http://localhost:5000/api/values)

--- a/docs/guides/security/sso-openid-netcore.md
+++ b/docs/guides/security/sso-openid-netcore.md
@@ -21,7 +21,7 @@ This is a guide to integrate a .Net Core API with the Cloud Foundry SSO identity
 
 First, **establish an identity provider**. Using the [Steeltoe dockerfile](https://github.com/steeltoeoss/dockerfiles), start a local instance of SSO.
 
-```powershell
+```shell
 docker run --rm -ti -p 8080:8080 --name steeltoe-uaa steeltoeoss/workshop-uaa-server
 ```
 
@@ -39,7 +39,7 @@ Next, **create a .NET Core WebAPI** that interacts with SSO
    <img src="/guides/images/open-package-manager-console.png" alt="Visual Studio - Package Manager Console" width="100%">
 1. Install NuGet packages
 
-   ```powershell
+   ```pwsh
    Install-Package Steeltoe.Security.Authentication.CloudFoundryCore
    ```
 
@@ -148,8 +148,8 @@ Then, **add** Cloud Foundry OpenID Connect, secure endpoints, and run the app
 
 # [.NET cli](#tab/cli)
 
-```powershell
-dotnet run<PATH_TO>\OAuthSSOExample.csproj
+```shell
+dotnet run <PATH_TO>\OAuthSSOExample.csproj
 ```
 
 Navigate to the endpoint (you may need to change the port number) [http://localhost:5000/api/values](http://localhost:5000/api/values)

--- a/docs/guides/service-connectors/mongo.md
+++ b/docs/guides/service-connectors/mongo.md
@@ -20,7 +20,7 @@ First, **start a Mongo DB instance**. Depending on your hosting platform this is
 
 1. Using the [Steeltoe dockerfile](https://github.com/steeltoeoss/dockerfiles), start a local instance of Mongo.
 
-   ```powershell
+   ```shell
    docker run --env MONGO_INITDB_ROOT_USERNAME=steeltoe --env MONGO_INITDB_ROOT_PASSWORD=Steeltoe234 --publish 27017:27017 mongo
    ```
 
@@ -53,7 +53,7 @@ Next, **create a .NET Core WebAPI** that interacts with Mongo DB
 
 # [.NET cli](#tab/cli)
 
-```powershell
+```shell
 dotnet run <PATH_TO>\MongoConnector.csproj
 ```
 

--- a/docs/guides/service-connectors/mssql.md
+++ b/docs/guides/service-connectors/mssql.md
@@ -18,7 +18,7 @@ This tutorial takes you through setting up a .NET Core application with the Micr
 
 First, **start an MsSQL instance** using the [Steeltoe dockerfile](https://github.com/steeltoeoss/dockerfiles).
 
-```powershell
+```shell
 docker run --env ACCEPT_EULA=Y --env SA_PASSWORD=Steeltoe123 --publish 1433:1433 steeltoeoss/mssql
 ```
 
@@ -51,7 +51,7 @@ Next, **create a .NET Core WebAPI** that interacts with MS SQL
 
 # [.NET cli](#tab/cli)
 
-```powershell
+```shell
 dotnet run <PATH_TO>\MsSqlConnector.csproj
 ```
 

--- a/docs/guides/service-connectors/mysql.md
+++ b/docs/guides/service-connectors/mysql.md
@@ -18,7 +18,7 @@ This tutorial takes you through setting up a .NET Core application with the MySQ
 
 First, **start a MySQL instance** using the [Steeltoe dockerfile](https://github.com/steeltoeoss/dockerfiles).
 
-```powershell
+```shell
 docker run --env MYSQL_ROOT_PASSWORD=Steeltoe456 --publish 3306:3306 steeltoeoss/mysql
 ```
 
@@ -51,7 +51,7 @@ Next, **create a .NET Core WebAPI** that interacts with MySQL
 
 # [.NET cli](#tab/cli)
 
-```powershell
+```shell
 dotnet run <PATH_TO>\MySqlConnector.csproj
 ```
 

--- a/docs/guides/service-connectors/postgresql.md
+++ b/docs/guides/service-connectors/postgresql.md
@@ -18,7 +18,7 @@ This tutorial takes you through setting up a .NET Core application with the Post
 
 First, **start a PostgreSQL instance** using the [Steeltoe dockerfile](https://github.com/steeltoeoss/dockerfiles).
 
-```powershell
+```shell
 docker run --env POSTGRES_PASSWORD=Steeltoe789 --publish 5432:5432 steeltoeoss/postgresql
 ```
 
@@ -51,7 +51,7 @@ Next, **create a .NET Core WebAPI** that interacts with PostgreSQL
 
 # [.NET cli](#tab/cli)
 
-```powershell
+```shell
 dotnet run <PATH_TO>\PostgreSqlConnector.csproj
 ```
 

--- a/docs/guides/service-connectors/rabbitmq.md
+++ b/docs/guides/service-connectors/rabbitmq.md
@@ -18,7 +18,7 @@ This tutorial takes you through setting up a .NET Core application with the Rabb
 
 First, **start a RabbitMQ instance** using the [Steeltoe dockerfile](https://github.com/steeltoeoss/dockerfiles).
 
-```powershell
+```shell
 docker run --publish 5672:5672 steeltoeoss/rabbitmq
 ```
 
@@ -71,7 +71,7 @@ Next, **create a .NET Core WebAPI** that interacts with RabbitMQ
 
 # [.NET cli](#tab/cli)
 
-```powershell
+```shell
 dotnet run <PATH_TO>\RabbitMQConnector.csproj
 ```
 
@@ -86,7 +86,7 @@ Navigate to the endpoint (you may need to change the port number) [http://localh
 
 As the app loads in the browser it will create a message queue, listen for new messages on the queue, and write 5 messages. Once finished the output will let you know everything has completed - "Wrote 5 message to the info log. Have a look!". Looking at the app logs (console) you will see...
 
-```bash
+```text
 Received message: Message 1
 Received message: Message 2
 Received message: Message 3

--- a/docs/guides/service-connectors/redis.md
+++ b/docs/guides/service-connectors/redis.md
@@ -18,7 +18,7 @@ This tutorial takes you through setting up a .NET Core application with the Redi
 
 First, **start a Redis instance** using the [Steeltoe dockerfile](https://github.com/steeltoeoss/dockerfiles).
 
-```powershell
+```shell
 docker run --publish 6379:6379 steeltoeoss/redis
 ```
 
@@ -48,7 +48,7 @@ Next, **create a .NET Core WebAPI** that interacts with Redis
 
 # [.NET cli](#tab/cli)
 
-```powershell
+```shell
 dotnet run <PATH_TO>\RedisConnector.csproj
 ```
 

--- a/docs/guides/service-discovery/consul.md
+++ b/docs/guides/service-discovery/consul.md
@@ -15,7 +15,7 @@ This tutorial takes you through setting up two .NET Core applications using serv
 
 First, **start a HashiCorp Consul server**. There are a variety of ways to get a Consul server, but using this command will create a server that will be cleaned up automatically after you stop it:
 
-```powershell
+```shell
 docker run --rm -ti -p 8500:8500 --name=steeltoe_guide_consul consul
 ```
 
@@ -37,12 +37,12 @@ Next, **create a .NET Core WebAPI** and configure Steeltoe to register with the 
 
 First, open your preferred shell and navigate to the folder you'd like the sample created in.
 
-```powershell
+```bash
 # create the project
 dotnet new webapi --name Consul_Register_Example
 
 # enter the project directory
-cd .\Consul_Register_Example\
+cd Consul_Register_Example
 
 # add the NuGet reference
 dotnet add Steeltoe.Discovery.Consul
@@ -67,7 +67,7 @@ Now when the application starts up, Steeltoe will activate the appropriate disco
 
 When the application is run directly, Steeltoe should be able to register with the default settings.
 
-```powershell
+```shell
 dotnet run
 ```
 
@@ -140,12 +140,12 @@ Once you've confirmed the service runs and registers correctly, **create another
 
 First, open your preferred shell and navigate to the folder you'd like the sample created in.
 
-```powershell
+```bash
 # create the project
 dotnet new webapi --name Consul_Discover_Example
 
 # enter the project directory
-cd .\Consul_Discover_Example\
+cd Consul_Discover_Example
 
 # add the NuGet reference
 dotnet add Steeltoe.Discovery.Consul
@@ -211,7 +211,7 @@ Run the app to see discovery in action:
 
 # [dotnet CLI](#tab/dotnet-run2)
 
-```powershell
+```shell
 cd Consul_Discover_Example
 dotnet run
 ```

--- a/docs/guides/service-discovery/eureka.md
+++ b/docs/guides/service-discovery/eureka.md
@@ -18,7 +18,7 @@ This tutorial takes you through setting up two .NET Core applications using serv
 
 First, **start a Eureka Server** using the [Steeltoe dockerfile](https://github.com/steeltoeoss/dockerfiles), start a local instance of Eureka.
 
-```powershell
+```shell
 docker run --publish 8761:8761 steeltoeoss/eureka-server
 ```
 
@@ -75,7 +75,7 @@ Next, **create a .NET Core WebAPI** that registers itself as a service.
 
 # [.NET cli](#tab/cli)
 
-```powershell
+```shell
 dotnet run <PATH_TO>\EurekaRegisterExample.csproj
 ```
 
@@ -168,7 +168,7 @@ Now, **create another .NET Core WebAPI** that will discover the registered servi
 
 # [.NET cli](#tab/cli)
 
-```powershell
+```shell
 dotnet run <PATH_TO>\EurekaDiscoverExample.csproj
 ```
 

--- a/docs/guides/stream/quick-start.md
+++ b/docs/guides/stream/quick-start.md
@@ -19,7 +19,7 @@ and abstractions, making it easier to digest the rest of this user guide.
 First, **start a rabbitmq server** locally using Docker:
 
 ```shell
-    docker run --name rabbitmq -p 5672:5672 -p 15672:15672 rabbitmq:3-management
+docker run --name rabbitmq -p 5672:5672 -p 15672:15672 rabbitmq:3-management
 ```
 
 1. [Creating a Sample Application by Using Steeltoe Initializr](https://start.steeltoe.io)
@@ -136,7 +136,7 @@ Assuming you have RabbitMQ installed and running, you can start the application 
 
 You should see following output:
 
-```shell
+```text
 info: Steeltoe.Messaging.RabbitMQ.Connection.CachingConnectionFactory[0]
       Attempting to connect to: amqp://127.0.0.1:5672
 info: Microsoft.Hosting.Lifetime[0]


### PR DESCRIPTION
Normalize the usage of code fences to the following set:

- "text" (use this instead of an empty fence, so that no syntax highlighting is applied)
- "markdown"
- "yaml"
- "json"
- "xml"
- "csharp"
- "java"
- "dockerfile"
- "shell", "pwsh", "bash", "cmd"

Updated shell fences to:
- Use `pwsh` when the command requires PowerShell or runs a `.ps1` script
- Use `bash` when the command requires bash (`curl`, `http`, etc)
- Use `cmd` when the command runs a `.bat` file
- Use `shell` when the command is shell-agnostic

I also removed shell prompts such as `$` and `PS>`, so that the code block can be copy/pasted.

In the v4 docs, I split up blocks such as:
```
# comment1
cd dir
# comment2
dotnet run
```

into individual blocks without comments, so that `shell` can be used. This is required because not all shells use the same syntax for comments. I didn't split occurrences in older documentation, just using `bash` there instead.

Fixes #334.