### PR TITLE
Show sample of Platform.IsCloudFoundry in documentation

### DIFF
--- a/docs/docs/v4/management/cloud-foundry.md
+++ b/docs/docs/v4/management/cloud-foundry.md
@@ -45,10 +45,11 @@ Add the following code to `Program.cs` to use the actuator endpoint:
 ```csharp
 using Steeltoe.Configuration.CloudFoundry;
 using Steeltoe.Management.Endpoint.Actuators.CloudFoundry;
-
 var builder = WebApplication.CreateBuilder(args);
-builder.Configuration.AddCloudFoundry();
-builder.Services.AddCloudFoundryActuator();
+if (Platform.IsCloudFoundry) {
+    builder.Configuration.AddCloudFoundry();
+    builder.Services.AddCloudFoundryActuator();
+}
 ```
 
 > [!TIP]


### PR DESCRIPTION
in #1674 Platform.IsCloudFoundry was used as an example. The Platform enum is never referenced in the documentation (only in the API), using it at least once might help users find it.