### PR TITLE
Fix the inner loop development when editing markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Follow the steps below to run/debug locally. The optional steps take longer, but
 1. Optional: Only process Markdown files in `docs`:
 
    ```shell
-   dotnet tool restore && dotnet docfx build docs/docfx.json --warningsAsErrors true
+   pwsh build/docfx-build.ps1
    ```
 
 1. Open [Steeltoe.io.slnx](src/Steeltoe.io.slnx) in your preferred IDE, or run from the command line:

--- a/build/docfx-build.ps1
+++ b/build/docfx-build.ps1
@@ -1,0 +1,29 @@
+#!/usr/bin/env pwsh
+
+set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function EnsureDocfxBinaries() {
+    # Temporary workaround until a proper DocFX build supporting .NET 10 is available.
+    $zipFile = [IO.Path]::Combine($env:TEMP, 'docfx-net10-binaries.zip')
+
+    if (!(Test-Path -Path 'docfx-net10-binaries')) {
+        Invoke-WebRequest -Uri 'https://ent.box.com/shared/static/3b9s1j71jmcsbjgug0yjel8fohk1n720.zip' -Method 'GET' -OutFile $zipFile
+        Expand-Archive $zipFile -Force
+    }
+}
+
+# Get the script's directory
+$baseDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+Push-Location $baseDir
+
+try {
+    EnsureDocfxBinaries
+
+    $buildArgs = @('exec', 'docfx-net10-binaries/docfx.dll', 'build', (Join-Path '..' 'docs' 'docfx.json'), '--warningsAsErrors', 'true')
+    Write-Output "Running command: dotnet $buildArgs"
+    dotnet $buildArgs
+}
+finally {
+    Pop-Location
+}


### PR DESCRIPTION
This PR replaces the `dotnet docfx build` step with a script that downloads our custom binaries and then executes the same command.

This enables quick iteration on editing handwritten documentation, ie:
1. Edit a markdown file in docs/docs and save it
2. Run the script
3. Use the existing command to start the website

To further edit files, you can leave the website running. Saving your changes and running the script again updates the website content.